### PR TITLE
Support async mirai cancellation upon timeout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Encoding: UTF-8
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.5.2.9000)
+    nanonext (>= 1.5.2.9001)
 Enhances: 
     parallel,
     promises

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 #### Updates
 
 * Fixes `stop_mirai()` failing to interrupt in certain cases on non-Windows platforms (thanks @LennardLux, #240).
-* Requires nanonext >= [1.5.2.9000].
+* Requires nanonext >= [1.5.2.9001].
 * Package is re-licensed under the MIT license.
 
 # mirai 2.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # mirai (development version)
 
+#### New Features
+
+`mirai()` argument `.timeout` is upgraded to automatically cancel ongoing mirai upon timeout when using dispatcher (thanks @be-marc, @sebffischer #251).
+
 #### Updates
 
 * Fixes `stop_mirai()` failing to interrupt in certain cases on non-Windows platforms (thanks @LennardLux, #240).

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -61,8 +61,11 @@
 #' @section Timeouts:
 #'
 #' Specifying the `.timeout` argument ensures that the mirai always resolves.
-#' However, the task may not have completed and still be ongoing in the daemon
-#' process. Use [stop_mirai()] instead to explicitly stop and interrupt a task.
+#' When using dispatcher, the mirai will be cancelled after it times out (as if
+#' [stop_mirai()] had been called). As in that case, there is no guarantee that
+#' any cancellation will be successful, if the code cannot be interrupted for
+#' instance. When not using dispatcher, the mirai task will continue to
+#' completion in the daemon process, even if it times out in the host process.
 #'
 #' @section Errors:
 #'

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -160,8 +160,8 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
   if (missing(.compute)) .compute <- .[["cp"]]
   envir <- ..[[.compute]]
   is.null(envir) && return(ephemeral_daemon(data, .timeout))
-  r <- request(.context(envir[["sock"]]), data, send_mode = 1L, recv_mode = 1L, timeout = .timeout, cv = envir[["cv"]])
-  `attr<-`(`attr<-`(r, "msgid", next_msgid(envir)), "profile", .compute)
+  r <- request(.context(envir[["sock"]]), data, send_mode = 1L, recv_mode = 1L, timeout = .timeout, cv = envir[["cv"]], msgid = next_msgid(envir))
+  `attr<-`(r, "profile", .compute)
 
 }
 

--- a/man/mirai.Rd
+++ b/man/mirai.Rd
@@ -76,8 +76,11 @@ being found.
 
 
 Specifying the \code{.timeout} argument ensures that the mirai always resolves.
-However, the task may not have completed and still be ongoing in the daemon
-process. Use \code{\link[=stop_mirai]{stop_mirai()}} instead to explicitly stop and interrupt a task.
+When using dispatcher, the mirai will be cancelled after it times out (as if
+\code{\link[=stop_mirai]{stop_mirai()}} had been called). As in that case, there is no guarantee that
+any cancellation will be successful, if the code cannot be interrupted for
+instance. When not using dispatcher, the mirai task will continue to
+completion in the daemon process, even if it times out in the host process.
 }
 
 \section{Errors}{


### PR DESCRIPTION
Closes #251.

Uses a new interface in nanonext.