### PR TITLE
Efficiency / Performance Improvements in mirai Creation and Cancellation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Encoding: UTF-8
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.5.2.9001)
+    nanonext (>= 1.5.2.9002)
 Enhances: 
     parallel,
     promises

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 #### Updates
 
 * Fixes `stop_mirai()` failing to interrupt in certain cases on non-Windows platforms (thanks @LennardLux, #240).
-* Requires nanonext >= [1.5.2.9001].
+* Requires nanonext >= [1.5.2.9002].
 * Package is re-licensed under the MIT license.
 
 # mirai 2.2.0

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -163,8 +163,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
   if (missing(.compute)) .compute <- .[["cp"]]
   envir <- ..[[.compute]]
   is.null(envir) && return(ephemeral_daemon(data, .timeout))
-  r <- request(.context(envir[["sock"]]), data, send_mode = 1L, recv_mode = 1L, timeout = .timeout, cv = envir[["cv"]], msgid = next_msgid(envir))
-  `attr<-`(r, "profile", .compute)
+  request(.context(envir[["sock"]]), data, send_mode = 1L, recv_mode = 1L, timeout = .timeout, cv = envir[["cv"]], msgid = next_msgid(envir))
 
 }
 
@@ -382,11 +381,9 @@ collect_mirai <- function(x, options = NULL) {
 stop_mirai <- function(x) {
 
   is.list(x) && return(invisible(rev(as.logical(lapply(rev(unclass(x)), stop_mirai)))))
-
-  .compute <- attr(x, "profile")
-  envir <- if (is.character(.compute)) ..[[.compute]]
   stop_aio(x)
-  invisible(length(envir[["msgid"]]) && query_dispatcher(envir[["sock"]], c(0L, attr(x, "msgid"))))
+  msgid <- .subset2(x, "msgid")
+  msgid > 0 && query_dispatcher(.subset2(x, "context"), c(0L, msgid))
 
 }
 


### PR DESCRIPTION
Courtesy of https://github.com/r-lib/nanonext/pull/111. We now have a reference to the original send context, so we can also use that for sending the cancellation request. We consequently no longer have to append the compute profile name as an attribute, so this makes mirai creation faster as well.