### PR TITLE
Efficiency / Performance Improvements in mirai Creation and Cancellation (follow up)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Encoding: UTF-8
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.5.2.9003)
+    nanonext (>= 1.5.2.9004)
 Enhances: 
     parallel,
     promises

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Encoding: UTF-8
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.5.2.9002)
+    nanonext (>= 1.5.2.9003)
 Enhances: 
     parallel,
     promises

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 #### Updates
 
 * Fixes `stop_mirai()` failing to interrupt in certain cases on non-Windows platforms (thanks @LennardLux, #240).
-* Requires nanonext >= [1.5.2.9002].
+* Requires nanonext >= [1.5.2.9003].
 * Package is re-licensed under the MIT license.
 
 # mirai 2.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 #### Updates
 
 * Fixes `stop_mirai()` failing to interrupt in certain cases on non-Windows platforms (thanks @LennardLux, #240).
-* Requires nanonext >= [1.5.2.9003].
+* Requires nanonext >= [1.5.2.9004].
 * Package is re-licensed under the MIT license.
 
 # mirai 2.2.0

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -163,7 +163,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
   if (missing(.compute)) .compute <- .[["cp"]]
   envir <- ..[[.compute]]
   is.null(envir) && return(ephemeral_daemon(data, .timeout))
-  request(.context(envir[["sock"]]), data, send_mode = 1L, recv_mode = 1L, timeout = .timeout, cv = envir[["cv"]], msgid = next_msgid(envir))
+  request(envir[["sock"]], data, send_mode = 1L, recv_mode = 1L, timeout = .timeout, cv = envir[["cv"]], msgid = next_msgid(envir))
 
 }
 
@@ -383,7 +383,7 @@ stop_mirai <- function(x) {
   is.list(x) && return(invisible(rev(as.logical(lapply(rev(unclass(x)), stop_mirai)))))
   stop_aio(x)
   aio <- .subset2(x, "aio")
-  !is.integer(aio) && attr(aio, "msgid") > 0 && query_dispatcher(attr(aio, "context"), c(0L, attr(aio, "msgid")))
+  !is.integer(aio) && attr(aio, "msgid") > 0 && query_dispatcher(attr(aio, "socket"), c(0L, attr(aio, "msgid")))
 
 }
 
@@ -556,9 +556,7 @@ ephemeral_daemon <- function(data, timeout) {
   url <- local_url()
   sock <- req_socket(url)
   system2(.command, args = c("-e", shQuote(sprintf("mirai:::.daemon(\"%s\")", url))), stdout = FALSE, stderr = FALSE, wait = FALSE)
-  aio <- request(.context(sock), data, send_mode = 1L, recv_mode = 1L, timeout = timeout, cv = NA)
-  `attr<-`(.subset2(aio, "aio"), "sock", sock)
-  aio
+  request(sock, data, send_mode = 1L, recv_mode = 1L, timeout = timeout, cv = NA)
 }
 
 deparse_safe <- function(x) if (length(x))

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -382,8 +382,8 @@ stop_mirai <- function(x) {
 
   is.list(x) && return(invisible(rev(as.logical(lapply(rev(unclass(x)), stop_mirai)))))
   stop_aio(x)
-  msgid <- .subset2(x, "msgid")
-  msgid > 0 && query_dispatcher(.subset2(x, "context"), c(0L, msgid))
+  aio <- .subset2(x, "aio")
+  !is.integer(aio) && attr(aio, "msgid") > 0 && query_dispatcher(attr(aio, "context"), c(0L, attr(aio, "msgid")))
 
 }
 

--- a/R/next.R
+++ b/R/next.R
@@ -80,7 +80,10 @@ next_stream <- function(envir) {
 }
 
 next_msgid <- function(envir) {
-  msgid <- envir[["msgid"]] + 1L
-  `[[<-`(envir, "msgid", msgid)
-  msgid
+  prev <- envir[["msgid"]]
+  if (is.integer(prev)) {
+    msgid <- prev + 1L
+    `[[<-`(envir, "msgid", msgid)
+    msgid
+  }
 }


### PR DESCRIPTION
Fixes errors introduced in #255. Notably `request()` argument `msgid` must be NULL if there is no relevant msgid, requiring a patch to the internal `next_msgid()`.

Additionally simplifies ephemeral mirai creation.