### PR TITLE
Eliminate use of 'error' argument for listen/dial

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mirai
 Title: Minimalist Async Evaluation Framework for R
-Version: 2.2.0.9010
+Version: 2.2.0.9011
 Authors@R: c(
     person("Charlie", "Gao", , "charlie.gao@shikokuchuo.net", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0750-061X")),
@@ -27,7 +27,7 @@ BugReports: https://github.com/r-lib/mirai/issues
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.5.2.9016)
+    nanonext (>= 1.5.2.9018)
 Suggests: 
     cli,
     litedown

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 * For all functions that use `.compute`, this argument has a new default of `NULL`, which continues to use the `default` profile (and hence should not result in any change in behaviour).
 * Fixes `stop_mirai()` failing to interrupt in certain cases on non-Windows platforms, and more robust interruption if `tools::SIGINT` is supplied or passed through to the `autoexit` argument of `daemon()` (thanks @LennardLux, #240).
 * `daemons()` dispatcher argument 'process', deprecated in mirai v2.1.0, is removed.
-* Requires nanonext >= [1.5.2.9016].
+* Requires nanonext >= [1.5.2.9018].
 * Package is re-licensed under the MIT license.
 
 # mirai 2.2.0

--- a/R/daemon.R
+++ b/R/daemon.R
@@ -195,7 +195,8 @@ daemon <- function(
   sock <- socket("rep")
   on.exit(reap(sock))
   pipe_notify(sock, cv = cv, remove = TRUE)
-  dial(sock, url = url, autostart = NA, error = TRUE)
+  xc <- dial(sock, url = url, autostart = NA)
+  xc && stop(nng_error(xc))
   `[[<-`(., "sock", sock)
   data <- eval_mirai(recv(sock, mode = 1L, block = TRUE))
   send(sock, data, mode = 1L, block = TRUE) || until(cv, .limit_short)
@@ -228,7 +229,8 @@ eval_mirai <- function(._mirai_.) {
 dial_and_sync_socket <- function(sock, url, asyncdial = FALSE, tls = NULL) {
   cv <- cv()
   pipe_notify(sock, cv = cv, add = TRUE)
-  dial(sock, url = url, autostart = asyncdial || NA, tls = tls, error = TRUE)
+  xc <- dial(sock, url = url, autostart = asyncdial || NA, tls = tls)
+  xc && stop(nng_error(xc))
   wait(cv)
   pipe_notify(sock, cv = NULL, add = TRUE)
 }

--- a/R/daemon.R
+++ b/R/daemon.R
@@ -195,8 +195,7 @@ daemon <- function(
   sock <- socket("rep")
   on.exit(reap(sock))
   pipe_notify(sock, cv = cv, remove = TRUE)
-  xc <- dial(sock, url = url, autostart = NA)
-  xc && stop(nng_error(xc))
+  dial(sock, url = url, autostart = NA, fail = "error")
   `[[<-`(., "sock", sock)
   data <- eval_mirai(recv(sock, mode = 1L, block = TRUE))
   send(sock, data, mode = 1L, block = TRUE) || until(cv, .limit_short)
@@ -229,8 +228,7 @@ eval_mirai <- function(._mirai_.) {
 dial_and_sync_socket <- function(sock, url, asyncdial = FALSE, tls = NULL) {
   cv <- cv()
   pipe_notify(sock, cv = cv, add = TRUE)
-  xc <- dial(sock, url = url, autostart = asyncdial || NA, tls = tls)
-  xc && stop(nng_error(xc))
+  dial(sock, url = url, autostart = asyncdial || NA, tls = tls, fail = "error")
   wait(cv)
   pipe_notify(sock, cv = NULL, add = TRUE)
 }

--- a/R/dispatcher.R
+++ b/R/dispatcher.R
@@ -79,8 +79,7 @@ dispatcher <- function(
   psock <- socket("poly")
   on.exit(reap(psock), add = TRUE, after = TRUE)
   m <- monitor(psock, cv)
-  xc <- listen(psock, url = url, tls = tls)
-  xc && stop(nng_error(xc))
+  listen(psock, url = url, tls = tls, fail = "error")
 
   msgid <- 0L
   inq <- outq <- list()

--- a/R/dispatcher.R
+++ b/R/dispatcher.R
@@ -79,7 +79,8 @@ dispatcher <- function(
   psock <- socket("poly")
   on.exit(reap(psock), add = TRUE, after = TRUE)
   m <- monitor(psock, cv)
-  listen(psock, url = url, tls = tls, error = TRUE)
+  xc <- listen(psock, url = url, tls = tls)
+  xc && stop(nng_error(xc))
 
   msgid <- 0L
   inq <- outq <- list()


### PR DESCRIPTION
To align with UI consistency updates at nanonext.