### PR TITLE
Prevent local daemon creation in a mirai map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * `daemon()` argument `autoexit` default of `TRUE` now ensures daemons are terminated with the parent process, rather than continuing with any in-progress tasks.
   Set to `NA` to retain the previous behaviour of having them automatically exit without interrupting ongoing tasks.
 * `daemon()` argument `dispatcher` now defaults to `TRUE` - please note when manually launching daemons.
-* Calling `daemons()` to create local daemons now errors if performed within a mirai map. This guards against excessive spawning of processes on a local machine.
+* Calling `daemons()` to create local daemons now errors if performed within a mirai map. This guards against excessive spawning of local processes on a single machine.
 
 #### New Features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * `daemon()` argument `autoexit` default of `TRUE` now ensures daemons are terminated with the parent process, rather than continuing with any in-progress tasks.
   Set to `NA` to retain the previous behaviour of having them automatically exit without interrupting ongoing tasks.
 * `daemon()` argument `dispatcher` now defaults to `TRUE` - please note when manually launching daemons.
+* Calling `daemons()` to create local daemons now errors if performed within a mirai map. This guards against excessive spawning of processes on a local machine.
 
 #### New Features
 

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -281,6 +281,7 @@ daemons <- function(
       ..[[.compute]] <- NULL -> envir
     } else if (is.null(envir)) {
       n > 0L || stop(._[["n_zero"]])
+      dynGet(".mirai_within_map", ifnotfound = FALSE) && stop(._[["within_map"]])
       envir <- init_envir_stream(seed)
       urld <- local_url()
       dots <- parse_dots(...)

--- a/R/map.R
+++ b/R/map.R
@@ -71,6 +71,21 @@
 #' To map over **columns** instead, first wrap a dataframe in [as.list()], or
 #' transpose a matrix using [t()].
 #'
+#' @section Nested Maps:
+#'
+#' At times you way wish to run maps within maps. To do this, the function
+#' provided to the outer map needs to include a call to [daemons()] to set
+#' daemons used by the inner map. To guard against inadvertently spawning an
+#' excessive number of daemons on the same machine, attempting to launch local
+#' daemons within a map using `daemons(n)` will error.
+#'
+#' A legitimate use of this pattern however is when the outer daemons are
+#' launched on remote machines, and you then wish to launch daemons locally on
+#' each of those machines. In this case, use the following solution: instead of
+#' a single call to `daemons(n)` make 2 separate calls to
+#' `daemons(url = local_url()); launch_local(n)`. This is equivalent, and is
+#' permitted from within a map.
+#'
 #' @examplesIf interactive()
 #' daemons(4)
 #'

--- a/R/map.R
+++ b/R/map.R
@@ -160,7 +160,7 @@ mirai_map <- function(
           mirai(
             .expr = do.call(.f, c(list(.x), .args), quote = TRUE),
             ...,
-            .args = list(.f = .f, .x = x, .args = .args),
+            .args = list(.f = .f, .x = x, .args = .args, .mirai_within_map = TRUE),
             .compute = .compute
           )
       ),
@@ -175,7 +175,7 @@ mirai_map <- function(
             mirai(
               .expr = do.call(.f, c(as.vector(.x, mode = "list"), .args), quote = TRUE),
               ...,
-              .args = list(.f = .f, .x = .x[i, ], .args = .args),
+              .args = list(.f = .f, .x = .x[i, ], .args = .args, .mirai_within_map = TRUE),
               .compute = .compute
             )
         ),
@@ -190,7 +190,7 @@ mirai_map <- function(
             mirai(
               .expr = do.call(.f, c(.x, .args), quote = TRUE),
               ...,
-              .args = list(.f = .f, .x = lapply(.x, `[[`, i), .args = .args),
+              .args = list(.f = .f, .x = lapply(.x, `[[`, i), .args = .args, .mirai_within_map = TRUE),
               .compute = .compute
             )
         ),

--- a/R/mirai-package.R
+++ b/R/mirai-package.R
@@ -85,7 +85,8 @@
     numeric_n = "`n` must be numeric, did you mean to provide `url`?",
     requires_daemons = "daemons must be set prior to a map operation",
     sync_daemons = "mirai: initial sync with daemon(s) [%d secs elapsed]",
-    sync_dispatcher = "mirai: initial sync with dispatcher [%d secs elapsed]"
+    sync_dispatcher = "mirai: initial sync with dispatcher [%d secs elapsed]",
+    within_map = "cannot create local daemons from within a mirai map"
   ),
   hash = TRUE
 )

--- a/man/mirai_map.Rd
+++ b/man/mirai_map.Rd
@@ -90,6 +90,23 @@ To map over \strong{columns} instead, first wrap a dataframe in \code{\link[=as.
 transpose a matrix using \code{\link[=t]{t()}}.
 }
 
+\section{Nested Maps}{
+
+
+At times you way wish to run maps within maps. To do this, the function
+provided to the outer map needs to include a call to \code{\link[=daemons]{daemons()}} to set
+daemons used by the inner map. To guard against inadvertently spawning an
+excessive number of daemons on the same machine, attempting to launch local
+daemons within a map using \code{daemons(n)} will error.
+
+A legitimate use of this pattern however is when the outer daemons are
+launched on remote machines, and you then wish to launch daemons locally on
+each of those machines. In this case, use the following solution: instead of
+a single call to \code{daemons(n)} make 2 separate calls to
+\verb{daemons(url = local_url()); launch_local(n)}. This is equivalent, and is
+permitted from within a map.
+}
+
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 daemons(4)

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -163,6 +163,7 @@ connection && {
   test_true(all(mirai_map(list(c(a = 1, b = 1, c = 1), 3), sum)[.flat] == 3))
   test_type("language", mirai_map(list(quote(1+2)), identity)[][[1]])
   test_class("Date", mirai_map(data.frame(x = as.Date("2020-01-01")), identity)[][[1]])
+  test_true(is_mirai_error(mirai_map(1:2, function(x) daemons(1))[][[1]]))
   test_zero(daemons(0L))
 }
 # parallel cluster tests


### PR DESCRIPTION
Closes #310.

Scope limited to local daemons creation of the type `daemons(6)`.

Offers an escape hatch of the form:
```r
daemons(url = local_url())
launch_local(6)
```

Example:

``` r
library(mirai)
daemons(2)
#> [1] 2
mirai_map(1:2, function(x) mirai::daemons(2))[]
#> [[1]]
#> 'miraiError' chr Error in mirai::daemons(2): cannot create local daemons from within a mirai map
#> [[2]]
#> 'miraiError' chr Error in mirai::daemons(2): cannot create local daemons from within a mirai map
daemons(0)
#> [1] 0
```

<sup>Created on 2025-06-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

FYI @hadley @DavisVaughan