### PR TITLE
Reverts #317 and solves differently

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mirai
 Title: Minimalist Async Evaluation Framework for R
-Version: 2.4.0.9000
+Version: 2.4.0.9001
 Authors@R: c(
     person("Charlie", "Gao", , "charlie.gao@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0750-061X")),
@@ -26,7 +26,7 @@ BugReports: https://github.com/r-lib/mirai/issues
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.6.1)
+    nanonext (>= 1.6.1.9001)
 Suggests: 
     cli,
     litedown
@@ -40,3 +40,4 @@ Config/usethis/last-upkeep: 2025-04-23
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Remotes: r-lib/nanonext

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,7 @@
 * Simplifies launches when using dispatcher - `launch_remote()` commands are now the same irrespective of the number of launches.
   This is as daemons now retrieve the next RNG stream from dispatcher rather than the `rs` argument to `daemon()`.
 * Deprecated `call_mirai_()` is now removed.
-* Requires nanonext >= 1.6.1.
+* Requires nanonext >= [1.6.1.9001].
 
 # mirai 2.3.0
 


### PR DESCRIPTION
By instead requiring nanonext >= 1.6.1.9001. i.e. this will automatically be resolved when the next version of nanonext is released.

Fixes #243, #317 more broadly and closer to source.