### PR TITLE
Pass L'Ecuyer streams from host to dispatcher in all cases

### DIFF
--- a/R/daemon.R
+++ b/R/daemon.R
@@ -127,11 +127,7 @@ daemon <- function(
     is.numeric(id) && send(sock, c(0L, as.integer(id)), mode = 2L, block = TRUE)
     wait(cv) || return(invisible(xc))
     bundle <- collect_aio(aio)
-    if (is.numeric(rs)) {
-      `[[<-`(.GlobalEnv, ".Random.seed", as.integer(rs))
-    } else if (!is.null(bundle[[1L]])) {
-      `[[<-`(.GlobalEnv, ".Random.seed", bundle[[1L]])
-    }
+    `[[<-`(.GlobalEnv, ".Random.seed", if (is.numeric(rs)) as.integer(rs) else bundle[[1L]])
     if (is.list(bundle[[2L]])) `opt<-`(sock, "serial", bundle[[2L]])
     snapshot()
     repeat {


### PR DESCRIPTION
Fixes #333. Regression in mirai 2.4.0.