### PR TITLE
Simplifies `dispatcher()` function signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,9 @@
 * `everywhere()` has been updated for robustness and ease of use:
   + Returns a `mirai_map` object for easier handling (rather than just a list of mirai).
   + When using dispatcher, no longer has the potential to fail if sending large data (#326).
+* `dispatcher()` function signature simplified with `rs`, `tls` and `pass` arguments removed (should have no effect as these are no longer passed via the arguments).
 * Fixes a bug where using non-dispatcher daemons, an `unresolvedValue` would very rarely be returned as the fulfilled value of a promise (thanks @James-G-Hill and @olivier7121, #243 and #317).
 * Fixes a regression in mirai 2.4.0 where the L'Ecuyer-CMRG seed was not being passed correctly for remote daemons (#333).
-* `dispatcher()` argument `rs` is removed (should not have any impact as this was never meant to be set by the user).
 * Requires nanonext >= [1.6.1.9001].
 
 # mirai 2.4.0

--- a/R/daemon.R
+++ b/R/daemon.R
@@ -248,4 +248,4 @@ snapshot <- function()
 flag_value_auto <- function(autoexit)
   { isFALSE(autoexit) || isNamespace(topenv(parent.frame(), NULL)) } && return(autoexit) || is.na(autoexit) || isNamespaceLoaded("covr") || return(tools::SIGTERM)
 
-flag_value <- function(signal = tools::SIGTERM) isNamespaceLoaded("covr") || return(signal)
+flag_value <- function() isNamespaceLoaded("covr") || return(tools::SIGTERM)

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -34,7 +34,6 @@
 #' optionally `.compute`) returns the value of [status()].
 #'
 #' @inheritParams mirai
-#' @inheritParams dispatcher
 #' @param n integer number of daemons to launch.
 #' @param url \[default NULL\] if specified, a character string comprising a URL
 #'   at which to listen for remote daemons, including a port accepting incoming
@@ -72,6 +71,9 @@
 #'   with the TLS certificate first), **or** a length 2 character vector
 #'   comprising \[i\] the TLS certificate (optionally certificate chain) and
 #'   \[ii\] the associated private key.
+#' @param pass \[default NULL\] (required only if the private key supplied to
+#'   `tls` is encrypted with a password) For security, should be provided
+#'   through a function that returns this value, rather than directly.
 #'
 #' @return The integer number of daemons launched locally (zero if specifying
 #'   `url` or using a remote launcher).

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -605,21 +605,19 @@ wa3 <- function(url, dots, rs = NULL, tls = NULL)
 
 wa4 <- function(urld, n, dots)
   shQuote(sprintf(
-    ".libPaths(c(\"%s\",.libPaths()));mirai::dispatcher(\"%s\",n=%d,signal=%d%s)",
+    ".libPaths(c(\"%s\",.libPaths()));mirai::dispatcher(\"%s\",n=%d%s)",
     libp(),
     urld,
     n,
-    tools::SIGTERM,
     dots
   ))
 
 wa5 <- function(urld, url, dots)
   shQuote(sprintf(
-    ".libPaths(c(\"%s\",.libPaths()));mirai::dispatcher(\"%s\",url=\"%s\",signal=%d%s)",
+    ".libPaths(c(\"%s\",.libPaths()));mirai::dispatcher(\"%s\",url=\"%s\"%s)",
     libp(),
     urld,
     url,
-    tools::SIGTERM,
     dots
   ))
 

--- a/R/dispatcher.R
+++ b/R/dispatcher.R
@@ -23,9 +23,6 @@
 #'   this case, a local url is automatically generated.
 #' @param ... (optional) additional arguments passed through to [daemon()].
 #'   These include `asyncdial`, `autoexit`, and `cleanup`.
-#' @param signal \[default TRUE\] integer signal to raise when the host
-#'   connection drops. This is always the value of `tools::SIGTERM` passed by
-#'   the host process.
 #'
 #' @return Invisible NULL.
 #'
@@ -35,8 +32,7 @@ dispatcher <- function(
   host,
   url = NULL,
   n = NULL,
-  ...,
-  signal = TRUE
+  ...
 ) {
   n <- if (is.numeric(n)) as.integer(n) else length(url)
   n > 0L || stop(._[["missing_url"]])
@@ -44,7 +40,7 @@ dispatcher <- function(
   cv <- cv()
   sock <- socket("rep")
   on.exit(reap(sock))
-  pipe_notify(sock, cv, remove = TRUE, flag = flag_value(signal))
+  pipe_notify(sock, cv, remove = TRUE, flag = flag_value())
   dial_sync_socket(sock, host)
 
   raio <- recv_aio(sock, mode = 1L, cv = cv)

--- a/R/dispatcher.R
+++ b/R/dispatcher.R
@@ -13,7 +13,6 @@
 #' tasks are only sent to daemons that can begin immediate execution of the
 #' task.
 #'
-#' @inheritParams daemon
 #' @param host the character URL dispatcher should dial in to, typically an IPC
 #'   address.
 #' @param url (optional) the character URL dispatcher should listen at (and
@@ -24,15 +23,6 @@
 #'   this case, a local url is automatically generated.
 #' @param ... (optional) additional arguments passed through to [daemon()].
 #'   These include `asyncdial`, `autoexit`, and `cleanup`.
-#' @param tls \[default NULL\] (required for secure TLS connections) **either**
-#'   the character path to a file containing the PEM-encoded TLS certificate and
-#'   associated private key (may contain additional certificates leading to a
-#'   validation chain, with the TLS certificate first), **or** a length 2
-#'   character vector comprising \[i\] the TLS certificate (optionally
-#'   certificate chain) and \[ii\] the associated private key.
-#' @param pass \[default NULL\] (required only if the private key supplied to
-#'   `tls` is encrypted with a password) For security, should be provided
-#'   through a function that returns this value, rather than directly.
 #' @param signal \[default TRUE\] integer signal to raise when the host
 #'   connection drops. This is always the value of `tools::SIGTERM` passed by
 #'   the host process.
@@ -46,8 +36,6 @@ dispatcher <- function(
   url = NULL,
   n = NULL,
   ...,
-  tls = NULL,
-  pass = NULL,
   signal = TRUE
 ) {
   n <- if (is.numeric(n)) as.integer(n) else length(url)
@@ -65,11 +53,12 @@ dispatcher <- function(
   if (nzchar(res[[1L]])) Sys.setenv(R_DEFAULT_PACKAGES = res[[1L]]) else
     Sys.unsetenv("R_DEFAULT_PACKAGES")
 
+  tls <- NULL
   auto <- is.null(url)
   if (auto) {
     url <- local_url()
   } else {
-    if (is.character(res[[2L]]) && is.null(tls)) {
+    if (is.character(res[[2L]])) {
       tls <- res[[2L]]
       pass <- res[[3L]]
     }
@@ -77,7 +66,7 @@ dispatcher <- function(
   }
   pass <- NULL
   serial <- res[[4L]]
-  stream <- res[[5L]]
+  res <- res[[5L]]
 
   psock <- socket("poly")
   on.exit(reap(psock), add = TRUE, after = TRUE)
@@ -88,7 +77,7 @@ dispatcher <- function(
   events <- integer()
   count <- 0L
   envir <- new.env(hash = FALSE, parent = emptyenv())
-  `[[<-`(envir, "stream", stream)
+  `[[<-`(envir, "stream", res)
   if (auto) {
     dots <- parse_dots(...)
     output <- attr(dots, "output")

--- a/man/dispatcher.Rd
+++ b/man/dispatcher.Rd
@@ -4,15 +4,7 @@
 \alias{dispatcher}
 \title{Dispatcher}
 \usage{
-dispatcher(
-  host,
-  url = NULL,
-  n = NULL,
-  ...,
-  tls = NULL,
-  pass = NULL,
-  signal = TRUE
-)
+dispatcher(host, url = NULL, n = NULL, ..., signal = TRUE)
 }
 \arguments{
 \item{host}{the character URL dispatcher should dial in to, typically an IPC
@@ -28,17 +20,6 @@ this case, a local url is automatically generated.}
 
 \item{...}{(optional) additional arguments passed through to \code{\link[=daemon]{daemon()}}.
 These include \code{asyncdial}, \code{autoexit}, and \code{cleanup}.}
-
-\item{tls}{[default NULL] (required for secure TLS connections) \strong{either}
-the character path to a file containing the PEM-encoded TLS certificate and
-associated private key (may contain additional certificates leading to a
-validation chain, with the TLS certificate first), \strong{or} a length 2
-character vector comprising [i] the TLS certificate (optionally
-certificate chain) and [ii] the associated private key.}
-
-\item{pass}{[default NULL] (required only if the private key supplied to
-\code{tls} is encrypted with a password) For security, should be provided
-through a function that returns this value, rather than directly.}
 
 \item{signal}{[default TRUE] integer signal to raise when the host
 connection drops. This is always the value of \code{tools::SIGTERM} passed by

--- a/man/dispatcher.Rd
+++ b/man/dispatcher.Rd
@@ -4,7 +4,7 @@
 \alias{dispatcher}
 \title{Dispatcher}
 \usage{
-dispatcher(host, url = NULL, n = NULL, ..., signal = TRUE)
+dispatcher(host, url = NULL, n = NULL, ...)
 }
 \arguments{
 \item{host}{the character URL dispatcher should dial in to, typically an IPC
@@ -20,10 +20,6 @@ this case, a local url is automatically generated.}
 
 \item{...}{(optional) additional arguments passed through to \code{\link[=daemon]{daemon()}}.
 These include \code{asyncdial}, \code{autoexit}, and \code{cleanup}.}
-
-\item{signal}{[default TRUE] integer signal to raise when the host
-connection drops. This is always the value of \code{tools::SIGTERM} passed by
-the host process.}
 }
 \value{
 Invisible NULL.


### PR DESCRIPTION
Closes #337.

- #336 already eliminates argument `rs`
- Removes arguments `tls` and `pass`
- Removes argument `signal`, calling `tools::SIGTERM` directly on dispatcher