### PR TITLE
Ensure reproducible RNG stream equivalence across dispatcher and non-dispatcher cases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mirai
 Title: Minimalist Async Evaluation Framework for R
-Version: 2.4.0.9002
+Version: 2.4.0.9003
 Authors@R: c(
     person("Charlie", "Gao", , "charlie.gao@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0750-061X")),

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -662,8 +662,9 @@ launch_dispatcher <- function(sock, args, output, serial, stream, tls = NULL, pa
 launch_daemons <- function(seq, sock, urld, dots, envir, output) {
   cv <- cv()
   pipe_notify(sock, cv, add = TRUE)
+  no_seed <- is.null(envir[["seed"]])
   for (i in seq)
-    launch_daemon(wa2(urld, dots, next_stream(envir)), output)
+    launch_daemon(wa2(urld, dots, if (no_seed) next_stream(envir)), output)
   sync <- 0L
   for (i in seq)
     while(!until(cv, .limit_long))

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -544,14 +544,10 @@ init_envir_stream <- function(seed) {
   oseed <- .GlobalEnv[[".Random.seed"]]
   RNGkind("L'Ecuyer-CMRG")
   if (length(seed)) set.seed(seed)
-  envir <- `[[<-`(
-    new.env(hash = FALSE, parent = ..),
-    "stream",
-    .GlobalEnv[[".Random.seed"]]
-  )
-  `[[<-`(envir, "seed", seed)
+  envir <- new.env(hash = FALSE, parent = ..)
+  `[[<-`(envir, "stream", .GlobalEnv[[".Random.seed"]])
   `[[<-`(.GlobalEnv, ".Random.seed", oseed)
-  envir
+  `[[<-`(envir, "seed", seed)
 }
 
 req_socket <- function(url, tls = NULL)
@@ -679,7 +675,6 @@ store_dispatcher <- function(envir, cv, sock, urld, res) {
   `[[<-`(envir, "cv", cv)
   `[[<-`(envir, "sock", sock)
   `[[<-`(envir, "dispatcher", urld)
-  `[[<-`(envir, "stream", NULL)
   `[[<-`(envir, "url", res[2L])
   `[[<-`(envir, "pid", as.integer(res[1L]))
 }

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -404,7 +404,7 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   m <- mirai_map(1:12, rnorm)[]
   test_zero(daemons(0))
   Sys.sleep(0.5)
-  test_equal(4L, daemons(4, seed = 1234L))
+  test_equal(4L, daemons(4, dispatcher = FALSE, seed = 1234L))
   n <- mirai_map(1:12, rnorm)[]
   test_zero(daemons(0))
   test_identical(m, n)

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -398,5 +398,16 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   test_equal(daemons()[["mirai"]][["completed"]], 20008L)
   test_zero(daemons(0))
 }
+# reproducible RNG tests
+connection && Sys.getenv("NOT_CRAN") == "true" && {
+  test_equal(4L, daemons(4, seed = 1234L))
+  m <- mirai_map(1:12, rnorm)[]
+  test_zero(daemons(0))
+  Sys.sleep(0.5)
+  test_equal(4L, daemons(4, seed = 1234L))
+  n <- mirai_map(1:12, rnorm)[]
+  test_zero(daemons(0))
+  test_identical(m, n)
+}
 test_zero(daemons(0))
 Sys.sleep(1L)


### PR DESCRIPTION
Definitively fixes #333.