### PR TITLE
Make reproducible seeds independent of daemon launches

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mirai
 Title: Minimalist Async Evaluation Framework for R
-Version: 2.4.0.9003
+Version: 2.4.0.9004
 Authors@R: c(
     person("Charlie", "Gao", , "charlie.gao@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0750-061X")),

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -662,9 +662,8 @@ launch_dispatcher <- function(sock, args, output, serial, stream, tls = NULL, pa
 launch_daemons <- function(seq, sock, urld, dots, envir, output) {
   cv <- cv()
   pipe_notify(sock, cv, add = TRUE)
-  no_seed <- is.null(envir[["seed"]])
   for (i in seq)
-    launch_daemon(wa2(urld, dots, if (no_seed) next_stream(envir)), output)
+    launch_daemon(wa2(urld, dots, maybe_next_stream(envir)), output)
   sync <- 0L
   for (i in seq)
     while(!until(cv, .limit_long))

--- a/R/launchers.R
+++ b/R/launchers.R
@@ -65,7 +65,7 @@ launch_local <- function(n = 1L, ..., tls = NULL, .compute = NULL) {
   output <- attr(dots, "output")
   if (is.null(tls)) tls <- envir[["tls"]]
   for (i in seq_len(n))
-    launch_daemon(write_args(url, dots, next_stream(envir), tls), output)
+    launch_daemon(write_args(url, dots, maybe_next_stream(envir), tls), output)
   n
 }
 
@@ -134,7 +134,7 @@ launch_remote <- function(
           cmds[i] <- sprintf(
             "%s -e %s",
             rscript,
-            write_args(url, dots, next_stream(envir), tls)
+            write_args(url, dots, maybe_next_stream(envir), tls)
           )
 
         for (i in seq_along(args))
@@ -160,7 +160,7 @@ launch_remote <- function(
     cmds[i] <- sprintf(
       "%s -e %s",
       rscript,
-      write_args(url, dots, next_stream(envir), tls)
+      write_args(url, dots, maybe_next_stream(envir), tls)
     )
 
   if (length(command))

--- a/R/next.R
+++ b/R/next.R
@@ -89,3 +89,8 @@ next_stream <- function(envir) {
   if (is.integer(stream)) `[[<-`(envir, "stream", parallel::nextRNGStream(stream))
   stream
 }
+
+maybe_next_stream <- function(envir) {
+  is.null(envir[["seed"]]) || return()
+  next_stream(envir)
+}

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -400,7 +400,10 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
 }
 # reproducible RNG tests
 connection && Sys.getenv("NOT_CRAN") == "true" && {
-  test_equal(4L, daemons(4, seed = 1234L))
+  test_equal(2L, daemons(2, seed = 1234L))
+  test_equal(1L, launch_local())
+  test_type("character", launch_remote())
+  Sys.sleep(1L)
   m <- mirai_map(1:12, rnorm)[]
   test_zero(daemons(0))
   Sys.sleep(0.5)


### PR DESCRIPTION
Follow up to #339. Ensures subsequent `launch_local()` and `launch_remote()` calls don't affect the stream when using a reproducible seed at `daemons()`, i.e. ensure that only `mirai()` advances the stream in this case.