### PR TITLE
Make safe consecutive `everywhere()` calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * `daemons()` gains a `tlscert` argument to specify custom TLS certificates to pass to the daemon.
   This replaces use of the `tls` argument at `launch_local()` and `launch_remote()`.
 * The `tls` argument at `launch_local()` and `launch_remote()` is deprecated.
+* `everywhere()` is less prescriptive on its use, with consecutive calls now permissible when using dispatcher (#354).
 * A `mirai()` evaluated on an ephemeral daemon now returns invisibly, consistent with other cases (#351).
 
 # mirai 2.4.1

--- a/man/everywhere.Rd
+++ b/man/everywhere.Rd
@@ -38,11 +38,7 @@ options are persisted regardless of a daemon's \code{cleanup} setting.
 \details{
 If using dispatcher, this function forces a synchronization point at
 dispatcher, whereby the \code{\link[=everywhere]{everywhere()}} call must have been evaluated on all
-daemons prior to subsequent evaluations taking place.
-
-It is an error to call \code{\link[=everywhere]{everywhere()}} successively without at least one
-\code{\link[=mirai]{mirai()}} call in between, as an ordinary mirai call is required to exit each
-synchronization point.
+daemons prior to subsequent mirai evaluations taking place.
 }
 \section{Evaluation}{
 
@@ -67,9 +63,11 @@ being found.
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 daemons(1)
+
 # export common data by a super-assignment expression:
 everywhere(y <<- 3)
 mirai(y)[]
+
 # '...' variables are assigned to the global environment
 # '.expr' may be specified as an empty {} in such cases:
 everywhere({}, a = 1, b = 2)
@@ -78,7 +76,9 @@ mirai(a + b - y == 0L)[]
 # everywhere() returns a mirai_map object:
 mp <- everywhere("just a normal operation")
 mp
-mp[]
+mp[.flat]
+mp <- everywhere(stop("everywhere"))
+collect_mirai(mp)
 daemons(0)
 
 # loading a package on all daemons

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -397,7 +397,7 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   for (i in seq_len(10000L)) {q[[i]] <- mirai({Sys.sleep(0.001); rnorm(1)}); attr(q[[i]], "status") <- status()}
   test_equal(length(unique(unlist(collect_mirai(q)))), 10000L)
   test_true(all(as.logical(lapply(lapply(q, attr, "status"), is.list))))
-  test_equal(daemons()[["mirai"]][["completed"]], 20008L)
+  test_equal(daemons()[["mirai"]][["completed"]], 20009L)
   test_zero(daemons(0))
 }
 # reproducible RNG tests

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -389,15 +389,16 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   Sys.setenv(R_DEFAULT_PACKAGES = "stats,utils")
   test_equal(daemons(4), 4L)
   Sys.unsetenv("R_DEFAULT_PACKAGES")
-  test_type("list", everywhere(a <<- TRUE))
-  test_true(all(mirai_map(1:4, function(x) { Sys.sleep(0.2); a})[.flat]))
+  test_class("mirai_map", everywhere(a <<- FALSE))
+  test_true(all(everywhere(a <<- TRUE)[.flat]))
+  test_true(all(mirai_map(1:10, function(x) a)[.flat]))
   for (i in seq_len(10000L)) {q[[i]] <- mirai(1L); attr(q[[i]], "status") <- status()}
   test_equal(sum(unlist(collect_mirai(q))), 10000L)
   test_true(all(as.logical(lapply(lapply(q, attr, "status"), is.list))))
   for (i in seq_len(10000L)) {q[[i]] <- mirai({Sys.sleep(0.001); rnorm(1)}); attr(q[[i]], "status") <- status()}
   test_equal(length(unique(unlist(collect_mirai(q)))), 10000L)
   test_true(all(as.logical(lapply(lapply(q, attr, "status"), is.list))))
-  test_equal(daemons()[["mirai"]][["completed"]], 20009L)
+  test_equal(daemons()[["mirai"]][["completed"]], 20020L)
   test_zero(daemons(0))
 }
 # reproducible RNG tests


### PR DESCRIPTION
Fixes #354 by automatically appending an empty `mirai()` evaluation at the end of the `everywhere()` call. This is invisible to the user, but ensures that the synchronization points at dispatcher are always exited.