### PR TITLE
Ensure `everywhere()` does not affect reproducible RNG

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,12 @@
 
 #### Updates
 
+* Enhancements to `everywhere()`:
+  + Consecutive `everywhere()` calls are now permissible again when using dispatcher (change of behaviour in v2.4.1) (#354).
+  + No longer has any effect on the RNG stream when using a reproducible `seed` value at `daemons()` (#356).
 * `daemons()` gains a `tlscert` argument to specify custom TLS certificates to pass to the daemon.
-  This replaces use of the `tls` argument at `launch_local()` and `launch_remote()`.
+  This replaces use of the `tls` argument at `launch_local()` and `launch_remote()` (#344).
 * The `tls` argument at `launch_local()` and `launch_remote()` is deprecated.
-* `everywhere()` is less prescriptive on its use, with consecutive calls now permissible when using dispatcher (#354).
 * A `mirai()` evaluated on an ephemeral daemon now returns invisibly, consistent with other cases (#351).
 
 # mirai 2.4.1

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -204,6 +204,11 @@ mirai <- function(
 #' dispatcher, whereby the [everywhere()] call must have been evaluated on all
 #' daemons prior to subsequent mirai evaluations taking place.
 #'
+#' Calling [everywhere()] does not affect the RNG stream for mirai calls when
+#' using a reproducible `seed` value at [daemons()]. This allows the seed
+#' associated for each mirai call to be the same, regardless of the number of
+#' daemons actually used to evaluate the code.
+#'
 #' @inheritParams mirai
 #'
 #' @return A 'mirai_map' (list of 'mirai' objects).
@@ -260,7 +265,12 @@ everywhere <- function(.expr, ..., .args = list(), .compute = NULL) {
   xlen <- if (is.null(envir[["dispatcher"]]))
     max(stat(envir[["sock"]], "pipes"), envir[["n"]]) else
       max(status(.compute)[["connections"]], 1L)
-  on.exit(.mark(FALSE))
+  seed <- envir[["seed"]]
+  `[[<-`(envir, "seed", NULL)
+  on.exit({
+    .mark(FALSE)
+    `[[<-`(envir, "seed", seed)
+  })
   .mark()
   vec <- lapply(
     seq_len(xlen),

--- a/man/everywhere.Rd
+++ b/man/everywhere.Rd
@@ -39,6 +39,11 @@ options are persisted regardless of a daemon's \code{cleanup} setting.
 If using dispatcher, this function forces a synchronization point at
 dispatcher, whereby the \code{\link[=everywhere]{everywhere()}} call must have been evaluated on all
 daemons prior to subsequent mirai evaluations taking place.
+
+Calling \code{\link[=everywhere]{everywhere()}} does not affect the RNG stream for mirai calls when
+using a reproducible \code{seed} value at \code{\link[=daemons]{daemons()}}. This allows the seed
+associated for each mirai call to be the same, regardless of the number of
+daemons actually used to evaluate the code.
 }
 \section{Evaluation}{
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -407,10 +407,12 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   test_equal(1L, launch_local())
   test_type("character", launch_remote())
   Sys.sleep(0.5)
+  test_true(all(everywhere(TRUE)[.flat]))
   m <- mirai_map(1:12, rnorm)[]
   test_zero(daemons(0))
   Sys.sleep(0.5)
   test_equal(4L, daemons(4, dispatcher = FALSE, seed = 1234L))
+  test_true(all(everywhere(TRUE)[.flat]))
   n <- mirai_map(1:12, rnorm)[]
   test_zero(daemons(0))
   test_identical(m, n)


### PR DESCRIPTION
The RNG seed is temporarily cleared and cached when making an `everywhere()` call, and reverted upon returning.