### PR TITLE
Updates to new developer functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # mirai (development version)
 
+#### Behavioural Changes
+
+* `require_daemons()` arguments have been updated to `.compute` first followed by `.call` for ease of use.
+
 #### Updates
 
 * Enhancements to `everywhere()`:

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -421,11 +421,11 @@ daemons_set <- function(.compute = NULL) {
 #' error for the user to set daemons, with a clickable function link if the
 #' \CRANpkg{cli} package is available.
 #'
-#' @param call (only used if the \CRANpkg{cli} package is installed) the
+#' @inheritParams mirai
+#' @param .call (only used if the \CRANpkg{cli} package is installed) the
 #'   execution environment of a currently running function, e.g.
 #'   `environment()`. The function will be mentioned in error messages as the
 #'   source of the error.
-#' @inheritParams mirai
 #'
 #' @return Logical `TRUE`, or else errors.
 #'
@@ -436,9 +436,9 @@ daemons_set <- function(.compute = NULL) {
 #'
 #' @export
 #'
-require_daemons <- function(call = environment(), .compute = NULL) {
+require_daemons <- function(.compute = NULL, .call = environment()) {
   ensure_cli_initialized()
-  daemons_set(.compute = .compute) || .[["require_daemons"]](call)
+  daemons_set(.compute = .compute) || .[["require_daemons"]](.call)
 }
 
 #' Create Serialization Configuration

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -398,7 +398,7 @@ status <- function(.compute = NULL) {
 #' Returns a logical value, whether or not daemons have been set for a given
 #' compute profile.
 #'
-#' @inheritParams status
+#' @inheritParams mirai
 #'
 #' @return Logical `TRUE` or `FALSE`.
 #'
@@ -425,7 +425,7 @@ daemons_set <- function(.compute = NULL) {
 #'   execution environment of a currently running function, e.g.
 #'   `environment()`. The function will be mentioned in error messages as the
 #'   source of the error.
-#' @inheritParams status
+#' @inheritParams mirai
 #'
 #' @return Logical `TRUE`, or else errors.
 #'

--- a/man/daemons_set.Rd
+++ b/man/daemons_set.Rd
@@ -7,10 +7,9 @@
 daemons_set(.compute = NULL)
 }
 \arguments{
-\item{.compute}{[default NULL] character value for the compute profile to
-query, or NULL to query the 'default' profile.
-
-\strong{or} a 'miraiCluster' to obtain its status.}
+\item{.compute}{[default NULL] character value for the compute profile
+to use (each has its own independent set of daemons), or NULL to use the
+'default' profile.}
 }
 \value{
 Logical \code{TRUE} or \code{FALSE}.

--- a/man/require_daemons.Rd
+++ b/man/require_daemons.Rd
@@ -12,10 +12,9 @@ execution environment of a currently running function, e.g.
 \code{environment()}. The function will be mentioned in error messages as the
 source of the error.}
 
-\item{.compute}{[default NULL] character value for the compute profile to
-query, or NULL to query the 'default' profile.
-
-\strong{or} a 'miraiCluster' to obtain its status.}
+\item{.compute}{[default NULL] character value for the compute profile
+to use (each has its own independent set of daemons), or NULL to use the
+'default' profile.}
 }
 \value{
 Logical \code{TRUE}, or else errors.

--- a/man/require_daemons.Rd
+++ b/man/require_daemons.Rd
@@ -4,17 +4,17 @@
 \alias{require_daemons}
 \title{Require Daemons}
 \usage{
-require_daemons(call = environment(), .compute = NULL)
+require_daemons(.compute = NULL, .call = environment())
 }
 \arguments{
-\item{call}{(only used if the \CRANpkg{cli} package is installed) the
-execution environment of a currently running function, e.g.
-\code{environment()}. The function will be mentioned in error messages as the
-source of the error.}
-
 \item{.compute}{[default NULL] character value for the compute profile
 to use (each has its own independent set of daemons), or NULL to use the
 'default' profile.}
+
+\item{.call}{(only used if the \CRANpkg{cli} package is installed) the
+execution environment of a currently running function, e.g.
+\code{environment()}. The function will be mentioned in error messages as the
+source of the error.}
 }
 \value{
 Logical \code{TRUE}, or else errors.


### PR DESCRIPTION
Updates the interface of `require_daemons()`, which is breaking, but better to break early given this is a new function. It is possible to deprecate, but it implies a suboptimal interface with `...` in the meantime.

Docs for `require_daemons()` and `daemons_set()` inherited from the wrong tag, and this is corrected.