### PR TITLE
Make `mirai_map()` support Arrow Tables and Polars DataFrames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@
 * `require_daemons()` arguments are swapped so that `.compute` comes before `call` for ease of use.
   Previous usage will work for the time being, although is deprecated and will be defunct in a future version.
 * Enhancements to `everywhere()`:
-  + Consecutive `everywhere()` calls are now permissible again when using dispatcher (change of behaviour in v2.4.1) (#354).
+  + Consecutive `everywhere()` calls are now permissible again when using dispatcher (behaviour update in v2.4.1) (#354).
   + No longer has any effect on the RNG stream when using a reproducible `seed` value at `daemons()` (#356).
+* `mirai_map()` now supports Arrow Tables and Polars DataFrames (#366).
 * `daemon()` gains a `tlscert` argument for custom TLS certificates.
   The change in argument name lets this be passed when making a `daemons()` call (#344).
 * The `tls` argument at `daemon()`, `launch_local()` and `launch_remote()` is deprecated.

--- a/R/map.R
+++ b/R/map.R
@@ -180,21 +180,7 @@ mirai_map <- function(
       names(.x)
     )
   } else {
-    if (is.matrix(.x)) {
-      `names<-`(
-        lapply(
-          seq_len(dx[1L]),
-          function(i)
-            mirai(
-              .expr = do.call(.f, c(`storage.mode<-`(.x, "list"), .args), quote = TRUE),
-              ...,
-              .args = list(.f = .f, .x = .x[i, ], .args = .args, .mirai_within_map = TRUE),
-              .compute = .compute
-            )
-        ),
-        dimnames(.x)[[1L]]
-      )
-    } else {
+    if (is.data.frame(.x)) {
       rn <- attr(.x, "row.names", exact = TRUE)
       `names<-`(
         lapply(
@@ -208,6 +194,20 @@ mirai_map <- function(
             )
         ),
         if (is.character(rn)) rn
+      )
+    } else {
+      `names<-`(
+        lapply(
+          seq_len(dx[1L]),
+          function(i)
+            mirai(
+              .expr = do.call(.f, c(as.list(.x), .args), quote = TRUE),
+              ...,
+              .args = list(.f = .f, .x = .x[i, ], .args = .args, .mirai_within_map = TRUE),
+              .compute = .compute
+            )
+        ),
+        dimnames(.x)[[1L]]
       )
     }
   }


### PR DESCRIPTION
Closes #366.

Note: makes `is.data.frame()` the special case for objects with `dim` attributes. All others (matrix, Arrow Tables, Polars DataFrames) now share the same code path.