### PR TITLE
Make `daemons()` calls reset any existing daemons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `daemons()` creating new daemons returns invisibly the character compute profile created.
   `daemons(0)` or `daemons(NULL)` resetting daemons returns invisible NULL (thanks @eliocamp, #384).
+* Calling `daemons()` will now reset any existing daemons for the same compute profile rather than error.
+  This means that an explicit `daemons(0)` is no longer required before applying new settings (#383).
 
 #### New Features
 

--- a/R/daemon.R
+++ b/R/daemon.R
@@ -76,8 +76,8 @@
 #' Setting to FALSE allows the daemon to persist indefinitely even when there is
 #' no longer a socket connection. This allows a host session to end and a new
 #' session to connect at the URL where the daemon is dialled in. Daemons must be
-#' terminated with `daemons(NULL)` in this case, which sends explicit exit
-#' signals to all connected daemons.
+#' terminated with `daemons(NULL)` in this case instead of `daemons(0)`. This
+#' sends explicit exit signals to all connected daemons.
 #'
 #' @export
 #'

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -12,23 +12,18 @@
 #' Use `daemons(0)` to reset daemon connections:
 #' \itemize{
 #'   \item All connected daemons and/or dispatchers exit automatically.
-#'   \item \pkg{mirai} reverts to the default behaviour of creating a new
+#'   \item Any as yet unresolved 'mirai' will return an 'errorValue' 19
+#'   (Connection reset).
+#'   \item [mirai()] reverts to the default behaviour of creating a new
 #'   background process for each request.
-#'   \item Any unresolved 'mirai' will return an 'errorValue' 19 (Connection
-#'   reset) after a reset.
-#'   \item Daemons must be reset before calling `daemons()` with revised
-#'   settings for a compute profile. Daemons may be added at any time by using
-#'   [launch_local()] or [launch_remote()] without needing to revise daemons
-#'   settings.
 #' }
 #'
 #' If the host session ends, all connected dispatcher and daemon processes
-#' automatically exit as soon as their connections are dropped (unless the
-#' daemons were started with `autoexit = FALSE`).
+#' automatically exit as soon as their connections are dropped.
 #'
-#' To reset persistent daemons started with `autoexit = FALSE`, use
-#' `daemons(NULL)` instead, which also sends exit signals to all connected
-#' daemons prior to resetting.
+#' Calling [daemons()] implicitly resets any existing daemons for the compute
+#' profile with `daemons(0)`. Instead, [launch_local()] or [launch_remote()] may
+#' be used to add daemons at any time without resetting daemons.
 #'
 #' For historical reasons, `daemons()` with no arguments (other than
 #' optionally `.compute`) returns the value of [status()].
@@ -252,7 +247,8 @@ daemons <- function(
         on.exit()
       }
     } else {
-      stop(sprintf(._[["daemons_set"]], .compute))
+      daemons(0, .compute = .compute)
+      return(eval(match.call(expand.dots = FALSE)))
     }
   } else {
     signal <- is.null(n)
@@ -282,7 +278,8 @@ daemons <- function(
       }
       create_profile(envir, .compute, n, dots)
     } else {
-      stop(sprintf(._[["daemons_set"]], .compute))
+      daemons(0, .compute = .compute)
+      return(eval(match.call(expand.dots = FALSE)))
     }
   }
 

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -248,7 +248,7 @@ daemons <- function(
       }
     } else {
       daemons(0, .compute = .compute)
-      return(eval(match.call(expand.dots = FALSE)))
+      return(eval(match.call()))
     }
   } else {
     signal <- is.null(n)
@@ -279,7 +279,7 @@ daemons <- function(
       create_profile(envir, .compute, n, dots)
     } else {
       daemons(0, .compute = .compute)
-      return(eval(match.call(expand.dots = FALSE)))
+      return(eval(match.call()))
     }
   }
 

--- a/R/mirai-package.R
+++ b/R/mirai-package.R
@@ -69,7 +69,6 @@
   list(
     arglen = "`n` must equal the length of `args`, or either must be 1",
     cluster_inactive = "cluster is no longer active",
-    daemons_set = "daemons already set for `%s` compute profile",
     daemons_unset = "daemons must be set to use launchers",
     dot_required = "`.` must be an element of the character vector(s) supplied to `args`",
     function_required = "`.f` must be of type function, not %s",

--- a/man/daemon.Rd
+++ b/man/daemon.Rd
@@ -113,7 +113,7 @@ the host process.
 Setting to FALSE allows the daemon to persist indefinitely even when there is
 no longer a socket connection. This allows a host session to end and a new
 session to connect at the URL where the daemon is dialled in. Daemons must be
-terminated with \code{daemons(NULL)} in this case, which sends explicit exit
-signals to all connected daemons.
+terminated with \code{daemons(NULL)} in this case instead of \code{daemons(0)}. This
+sends explicit exit signals to all connected daemons.
 }
 

--- a/man/daemons.Rd
+++ b/man/daemons.Rd
@@ -89,23 +89,18 @@ scheduling.
 Use \code{daemons(0)} to reset daemon connections:
 \itemize{
 \item All connected daemons and/or dispatchers exit automatically.
-\item \pkg{mirai} reverts to the default behaviour of creating a new
+\item Any as yet unresolved 'mirai' will return an 'errorValue' 19
+(Connection reset).
+\item \code{\link[=mirai]{mirai()}} reverts to the default behaviour of creating a new
 background process for each request.
-\item Any unresolved 'mirai' will return an 'errorValue' 19 (Connection
-reset) after a reset.
-\item Daemons must be reset before calling \code{daemons()} with revised
-settings for a compute profile. Daemons may be added at any time by using
-\code{\link[=launch_local]{launch_local()}} or \code{\link[=launch_remote]{launch_remote()}} without needing to revise daemons
-settings.
 }
 
 If the host session ends, all connected dispatcher and daemon processes
-automatically exit as soon as their connections are dropped (unless the
-daemons were started with \code{autoexit = FALSE}).
+automatically exit as soon as their connections are dropped.
 
-To reset persistent daemons started with \code{autoexit = FALSE}, use
-\code{daemons(NULL)} instead, which also sends exit signals to all connected
-daemons prior to resetting.
+Calling \code{\link[=daemons]{daemons()}} implicitly resets any existing daemons for the compute
+profile with \code{daemons(0)}. Instead, \code{\link[=launch_local]{launch_local()}} or \code{\link[=launch_remote]{launch_remote()}} may
+be used to add daemons at any time without resetting daemons.
 
 For historical reasons, \code{daemons()} with no arguments (other than
 optionally \code{.compute}) returns the value of \code{\link[=status]{status()}}.

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -84,7 +84,6 @@ connection && {
   Sys.sleep(1L)
   test_equal("default", d <- daemons(1L, dispatcher = FALSE, asyncdial = FALSE, seed = 1546L))
   test_print(d)
-  test_error(daemons(1L), "daemons already set")
   test_true(daemons_set())
   test_true(require_daemons(parent.frame()))
   me <- mirai(mirai::mirai(), .timeout = 2000L)[]
@@ -133,7 +132,6 @@ connection && {
   Sys.sleep(1L)
   test_type("integer", status(.compute = "new")[["connections"]])
   test_error(mirai_map(1:2, "a function", .compute = "new"), "must be of type function, not character")
-  test_error(daemons(url = local_url(), .compute = "new"), "daemons already set")
   test_null(daemons(0L, .compute = "new"))
 }
 # additional daemons tests
@@ -259,7 +257,6 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   test_zero(status[["mirai"]][["awaiting"]])
   test_zero(status[["mirai"]][["executing"]])
   test_zero(status[["mirai"]][["completed"]])
-  test_null(daemons(0))
   test_nzchar(daemons(2, correcttype = NA))
   test_equal(daemons()[["connections"]], 2L)
   test_type("list", res <- mirai_map(c(1,1), rnorm)[.progress])
@@ -277,8 +274,6 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   m <- mirai("Seattle", .timeout = 1000)
   if (!is_error_value(m[])) test_equal(m[], "Seattle")
   test_class("errorValue", mirai(q(), .timeout = 1000)[])
-  test_null(daemons(0))
-  Sys.sleep(0.5)
   test_nzchar(daemons(n = 1L, url = local_url(), dispatcher = TRUE))
   task <- mirai(substitute())
   url <- nextget("url")


### PR DESCRIPTION
Closes #383.

Revert mirai to the behaviour prior to 2.1.0.