### PR TITLE
Sequential fallback for `mirai_map()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
   `daemons(0)` or `daemons(NULL)` resetting daemons returns invisible NULL (thanks @eliocamp, #384).
 * Calling `daemons()` will now reset any existing daemons for the same compute profile rather than error.
   This means that an explicit `daemons(0)` is no longer required before applying new settings (#383).
+* `mirai_map()` will automatically create one local daemon if daemons have not already been set.
+  This ensures that the map will always proceed, but sequentially rather than in parallel (#397).
 
 #### New Features
 

--- a/R/map.R
+++ b/R/map.R
@@ -158,7 +158,8 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = N
   if (is.null(.compute)) .compute <- .[["cp"]]
   require_daemons(.compute = .compute, call = environment())
   is.function(.f) || stop(sprintf(._[["function_required"]], typeof(.f)))
-  if (!daemons_set(.compute)) daemons(1L, dispatcher = FALSE, .compute = .compute)
+  if (is.null(.compute)) .compute <- .[["cp"]]
+  if (is.null(..[[.compute]])) daemons(1L, dispatcher = FALSE, .compute = .compute)
 
   dx <- dim(.x)
   vec <- if (is.null(dx)) {

--- a/R/map.R
+++ b/R/map.R
@@ -155,11 +155,14 @@
 #' @export
 #'
 mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = NULL) {
-  if (is.null(.compute)) .compute <- .[["cp"]]
-  require_daemons(.compute = .compute, call = environment())
   is.function(.f) || stop(sprintf(._[["function_required"]], typeof(.f)))
   if (is.null(.compute)) .compute <- .[["cp"]]
-  if (is.null(..[[.compute]])) daemons(1L, dispatcher = FALSE, .compute = .compute)
+  if (is.null(..[[.compute]])) {
+    .compute <- random(10L)
+    dx <- dim(.x)
+    maxtasks <- if (is.null(dx)) length(.x) else dx[1L]
+    daemons(1L, dispatcher = FALSE, maxtasks = maxtasks, .compute = .compute)
+  }
 
   dx <- dim(.x)
   vec <- if (is.null(dx)) {

--- a/R/map.R
+++ b/R/map.R
@@ -16,8 +16,9 @@
 #' Facilitates recovery from partial failure by returning all 'miraiError' /
 #' 'errorValue' as the case may be, thus allowing only failures to be re-run.
 #'
-#' This function requires daemons to have previously been set, and will error
-#' otherwise.
+#' This function will launch one (non-dispatcher) local daemon if daemons have
+#' not previously been set by the user. This allows [mirai_map()] to always
+#' proceed, although sequentially rather than in parallel in this case.
 #'
 #' @param .x a list or atomic vector. Also accepts a matrix or dataframe, in
 #'   which case multiple map is performed over its rows.
@@ -157,6 +158,7 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = N
   if (is.null(.compute)) .compute <- .[["cp"]]
   require_daemons(.compute = .compute, call = environment())
   is.function(.f) || stop(sprintf(._[["function_required"]], typeof(.f)))
+  if (!daemons_set(.compute)) daemons(1L, dispatcher = FALSE, .compute = .compute)
 
   dx <- dim(.x)
   vec <- if (is.null(dx)) {

--- a/dev/vignettes/_v01-map.Rmd
+++ b/dev/vignettes/_v01-map.Rmd
@@ -27,7 +27,7 @@ A `mirai_map()` call returns almost immediately on the other hand.
 The results of a mirai_map `x` may be collected using `x[]` or `collect_mirai(x)`, the same as for a mirai.
 This waits for all asynchronous operations to complete if still in progress.
 
-Use of `mirai_map()` requires that `daemons()` have previously been set, and will error if this is not the case (rather than launching potentially too many *ephemeral daemons* if the map is over a large number of elements).
+`daemons()` should have been set prior to `mirai_map()`. If not, then a single (non-dispatcher) local daemon is launched. This ensures that a map always proceeds, but in this case sequentially rather than in parallel.
 
 ### 2. Key Advantages
 

--- a/man/mirai_map.Rd
+++ b/man/mirai_map.Rd
@@ -48,8 +48,9 @@ This simple and transparent behaviour is designed to make full use of
 Facilitates recovery from partial failure by returning all 'miraiError' /
 'errorValue' as the case may be, thus allowing only failures to be re-run.
 
-This function requires daemons to have previously been set, and will error
-otherwise.
+This function will launch one (non-dispatcher) local daemon if daemons have
+not previously been set by the user. This allows \code{\link[=mirai_map]{mirai_map()}} to always
+proceed, although sequentially rather than in parallel in this case.
 }
 \section{Collection Options}{
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -22,7 +22,6 @@ test_null(daemons(0L))
 test_error(mirai(), "missing expression, perhaps wrap in {}?")
 test_error(mirai(a, 1), "all `...` arguments must be named")
 test_error(mirai(a, .args = list(1)), "all items in `.args` must be named")
-test_error(mirai_map(1:2, identity))
 test_error(daemons(url = "URL"), "Invalid argument")
 test_error(daemons(-1), "zero or greater")
 test_error(daemons(raw(0L)), "must be numeric")
@@ -150,14 +149,13 @@ connection && {
 # mirai_map tests
 connection && {
   Sys.sleep(1L)
-  m <- with(daemons(1, dispatcher = FALSE, .compute = "ml"), {
-    if (is.null(tryCatch(mirai_map(list(1, "a", 2), sum)[.stop], error = function(e) NULL)))
-      mirai_map(1:3, rnorm, .args = list(mean = 20, 2))[]
-  })
+  m <- if (is.null(tryCatch(mirai_map(list(1, "a", 2), sum)[.stop], error = function(e) NULL)))
+    mirai_map(1:3, rnorm, .args = list(mean = 20, 2))[]
   test_true(!is_mirai_map(m))
   test_type("list", m)
   test_equal(length(m), 3L)
   test_true(all(as.logical(lapply(m, is.numeric))))
+  test_null(daemons(0))
   Sys.sleep(1L)
   test_nzchar(daemons(1, dispatcher = FALSE))
   mp <- mirai_map(list(x = "a"), function(...) do(...), do = function(x, y) sprintf("%s%s", x, y), .args = list("b"))

--- a/vignettes/v01-map.Rmd
+++ b/vignettes/v01-map.Rmd
@@ -20,7 +20,7 @@ A `mirai_map()` call returns almost immediately on the other hand.
 The results of a mirai_map `x` may be collected using `x[]` or `collect_mirai(x)`, the same as for a mirai.
 This waits for all asynchronous operations to complete if still in progress.
 
-Use of `mirai_map()` requires that `daemons()` have previously been set, and will error if this is not the case (rather than launching potentially too many *ephemeral daemons* if the map is over a large number of elements).
+`daemons()` should have been set prior to `mirai_map()`. If not, then a single (non-dispatcher) local daemon is launched. This ensures that a map always proceeds, but in this case sequentially rather than in parallel.
 
 ### 2. Key Advantages
 
@@ -38,10 +38,10 @@ daemons(4)
 vec <- c(1, 1, 4, 4, 1, 1, 1, 1)
 system.time(mirai_map(vec, Sys.sleep)[])
 #>    user  system elapsed 
-#>   0.004   0.016   4.009
+#>   0.006   0.004   4.007
 system.time(parLapply(cl, vec, Sys.sleep))
 #>    user  system elapsed 
-#>   0.005   0.015   8.009
+#>   0.006   0.004   8.010
 daemons(0)
 ```
 `.args` is used to specify further constant arguments to `.f` - the `mean` and `sd` in the example below:
@@ -52,13 +52,13 @@ with(
   mirai_map(1:3, rnorm, .args = list(mean = 20, sd = 2))[]
 )
 #> [[1]]
-#> [1] 21.59418
+#> [1] 24.66414
 #> 
 #> [[2]]
-#> [1] 20.64373 16.25799
+#> [1] 19.22547 22.68882
 #> 
 #> [[3]]
-#> [1] 18.89357 20.91331 17.67060
+#> [1] 19.09580 21.02673 21.21549
 ```
 Use `...` to further specify objects referenced but not defined in `.f` - the function `do` below:
 
@@ -70,16 +70,16 @@ ml <- mirai_map(
   do = nanonext::random
 )
 ml
-#> < mirai map [2/3] >
+#> < mirai map [0/3] >
 ml[]
 #> $a
-#> [1] "4e"
+#> [1] "bb"
 #> 
 #> $b
-#> [1] 20 dc
+#> [1] b0 99
 #> 
 #> $c
-#> [1] "1a19e8"
+#> [1] "88c109"
 ```
 
 ### 3. Collecting Results


### PR DESCRIPTION
Closes #397. Reverts behaviour to that of mirai pre-2.1.0.