### PR TITLE
`daemons()` with no arguments no longer returns `status()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,14 +2,16 @@
 
 #### Behavioural Changes
 
-* `daemons()` now returns invisibly logical `TRUE` when creating daemons and `FALSE` when resetting them, for simplicity and consistency (#384).
-* `daemons()` creating new daemons now resets any existing daemons for the compute profile rather than error.
-  This means that an explicit `daemons(0)` is no longer required before applying new settings (thanks @eliocamp, #383).
+* Behavioural changes for `daemons()`:
+  + Returns invisibly logical `TRUE` when creating daemons and `FALSE` when resetting, for simplicity and consistency (#384).
+  + Creating new daemons resets any existing daemons for the compute profile rather than error.
+    This means that an explicit `daemons(0)` is no longer required before applying new settings (thanks @eliocamp, #383).
+  + Calling without supplying any arguments now errors rather than return the value of `status()`.
 
 #### New Features
 
 * Adds `with_daemons()` and `local_daemons()` helper functions for using a particular compute profile.
-  This works with daemons that are already set up unlike the existing `with.miraiDaemons()` method, which creates a new scope and tears it down when finished (#360).
+  These work with daemons that are already set up unlike the existing `with.miraiDaemons()` method, which creates a new scope and tears it down when finished (#360).
 * A mirai now has an attribute `id`, which is a monotonically increasing integer identifier unique to each session.
 
 #### Updates

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -25,9 +25,6 @@
 #' profile with `daemons(0)`. Instead, [launch_local()] or [launch_remote()] may
 #' be used to add daemons at any time without resetting daemons.
 #'
-#' For historical reasons, `daemons()` with no arguments (other than
-#' optionally `.compute`) returns the value of [status()].
-#'
 #' @inheritParams mirai
 #' @param n integer number of daemons to launch.
 #' @param url \[default NULL\] if specified, a character string comprising a URL
@@ -225,8 +222,6 @@ daemons <- function(
   pass = NULL,
   .compute = NULL
 ) {
-  missing(n) && missing(url) && return(status(.compute))
-
   if (is.null(.compute)) .compute <- .[["cp"]]
   envir <- ..[[.compute]]
 

--- a/man/daemons.Rd
+++ b/man/daemons.Rd
@@ -101,9 +101,6 @@ automatically exit as soon as their connections are dropped.
 Calling \code{\link[=daemons]{daemons()}} implicitly resets any existing daemons for the compute
 profile with \code{daemons(0)}. Instead, \code{\link[=launch_local]{launch_local()}} or \code{\link[=launch_remote]{launch_remote()}} may
 be used to add daemons at any time without resetting daemons.
-
-For historical reasons, \code{daemons()} with no arguments (other than
-optionally \code{.compute}) returns the value of \code{\link[=status]{status()}}.
 }
 \section{Local Daemons}{
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -250,7 +250,7 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   test_type("integer", nextget("pid"))
   test_equal(length(nextget("url")), 1L)
   Sys.sleep(1L)
-  status <- daemons()
+  status <- status()
   test_type("list", status)
   test_zero(status[["connections"]])
   test_type("integer", status[["mirai"]])
@@ -258,7 +258,7 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   test_zero(status[["mirai"]][["executing"]])
   test_zero(status[["mirai"]][["completed"]])
   test_true(daemons(2, correcttype = NA))
-  test_equal(daemons()[["connections"]], 2L)
+  test_equal(status()[["connections"]], 2L)
   test_type("list", res <- mirai_map(c(1,1), rnorm)[.progress])
   test_type("double", res[[1L]])
   test_type("double", res[[2L]])
@@ -404,7 +404,7 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   for (i in seq_len(10000L)) {q[[i]] <- mirai({Sys.sleep(0.001); rnorm(1)}); attr(q[[i]], "status") <- status()}
   test_equal(length(unique(unlist(collect_mirai(q)))), 10000L)
   test_true(all(as.logical(lapply(lapply(q, attr, "status"), is.list))))
-  test_equal(daemons()[["mirai"]][["completed"]], 20020L)
+  test_equal(status()[["mirai"]][["completed"]], 20020L)
   test_false(daemons(0))
 }
 # reproducible RNG tests


### PR DESCRIPTION
Ensuring stability of return types, as follow up to #412.