### PR TITLE
Revert miraiError condition class inheritance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 
 * `stop_mirai()` is more efficient and responsive, especially for 'mirai_map' objects (#417).
 * `miraiError` enhancements:
-  + Preserves the original condition classes and may be re-thrown as the original condition (thanks @sebffischer, #400).
+  + The original condition classes are preserved as `$condition.class` (thanks @sebffischer, #400).
   + The print method includes the customary additional line break (thanks @sebffischer, #399).
 * Fixes `daemons(n)` failing to launch local daemons if mirai was installed in a custom user library set by an explicit `.libPaths()` call in '.Rprofile' (thanks @erydit and @dpastoor, #390).
 * Improved behaviour for `serial_config()` custom serialization.

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -627,6 +627,7 @@ deparse_safe <- function(x) {
 mk_interrupt_error <- function() .miraiInterrupt
 
 mk_mirai_error <- function(cnd, sc) {
+  cnd[["condition.class"]] <- class(cnd)
   cnd[["call"]] <- `attributes<-`(.subset2(cnd, "call"), NULL)
   call <- deparse_safe(.subset2(cnd, "call"))
   msg <- if (
@@ -642,7 +643,7 @@ mk_mirai_error <- function(cnd, sc) {
   sc <- sc[(length(sc) - 1L):(idx + 1L)]
   if (sc[[1L]][[1L]] == ".handleSimpleError") sc <- sc[-1L]
   cnd[["stack.trace"]] <- lapply(sc, `attributes<-`, NULL)
-  `class<-`(`attributes<-`(msg, cnd), c("miraiError", "errorValue", "try-error", class(cnd)))
+  `class<-`(`attributes<-`(msg, cnd), c("miraiError", "errorValue", "try-error"))
 }
 
 .miraiInterrupt <- `class<-`("", c("miraiInterrupt", "errorValue", "try-error"))

--- a/dev/vignettes/_mirai.Rmd
+++ b/dev/vignettes/_mirai.Rmd
@@ -143,7 +143,7 @@ m3[]
 
 m3$data$stack.trace
 ```
-A 'miraiError' inherits from the original condition classes and hence can be caught or re-thrown. The elements of the original error condition are also accessible via `$` on the error object. Additional metadata recorded by `rlang::abort()` is preserved:
+The original condition classes are preserved at `$condition.class` on the error object. The elements of the original error condition are also accessible via `$` on the error object. Additional metadata recorded by `rlang::abort()` is preserved:
 ```{r}
 #| label: metaexample
 f <- function(x) if (x > 0) stop("positive")
@@ -152,6 +152,7 @@ m4 <- mirai(rlang::abort("aborted", meta_uid = "UID001"))
 m4[]
 
 m4$data$meta_uid
+m4$data$condition.class
 ```
 If a daemon instance is sent a user interrupt, the mirai will resolve to an object of class 'miraiInterrupt' and 'errorValue'.
 

--- a/vignettes/mirai.Rmd
+++ b/vignettes/mirai.Rmd
@@ -53,9 +53,9 @@ unresolved(m)
 # Do work whilst unresolved
 
 m[]
-#> [1] 4.897650 4.096580 5.078189 5.236960 3.512786
+#> [1] 3.671165 5.079939 5.555474 4.751527 2.825540
 m$data
-#> [1] 4.897650 4.096580 5.078189 5.236960 3.512786
+#> [1] 3.671165 5.079939 5.555474 4.751527 2.825540
 ```
 
 A mirai is either *unresolved* if the result has yet to be received, or *resolved* if it has. `unresolved()` is a helper function to check the state of a mirai.
@@ -79,7 +79,7 @@ args <- list(time = 2L, mean = 4)
 
 m1 <- mirai(.expr = expr, .args = args)
 m1[]
-#> [1] 5.617032 4.966253 3.991497 6.033833 2.806785
+#> [1] 3.600066 3.969468 2.177895 4.451550 2.246968
 ```
 
 The example below uses `mirai()` to perform a long-running write operation asynchronously from a separate process.
@@ -154,7 +154,7 @@ m3$data$stack.trace
 #> [[2]]
 #> f(1)
 ```
-A 'miraiError' inherits from the original condition classes and hence can be caught or re-thrown. The elements of the original error condition are also accessible via `$` on the error object. Additional metadata recorded by `rlang::abort()` is preserved:
+The original condition classes are preserved at `$condition.class` on the error object. The elements of the original error condition are also accessible via `$` on the error object. Additional metadata recorded by `rlang::abort()` is preserved:
 
 ``` r
 f <- function(x) if (x > 0) stop("positive")
@@ -165,6 +165,8 @@ m4[]
 
 m4$data$meta_uid
 #> [1] "UID001"
+m4$data$condition.class
+#> [1] "rlang_error" "error"       "condition"
 ```
 If a daemon instance is sent a user interrupt, the mirai will resolve to an object of class 'miraiInterrupt' and 'errorValue'.
 
@@ -259,7 +261,7 @@ status()
 #> [1] 6
 #> 
 #> $daemons
-#> [1] "ipc:///tmp/a3511b61eb7b8c39a2ac1b13"
+#> [1] "abstract://d8eceb74fe026901c1cc11bb"
 #> 
 #> $mirai
 #>  awaiting executing completed 
@@ -297,7 +299,7 @@ status()
 #> [1] 6
 #> 
 #> $daemons
-#> [1] "ipc:///tmp/05efdcdc660d0a53ed49ec88"
+#> [1] "abstract://da4f7f30cc25aa7af0535964"
 ```
 
 #### everywhere()
@@ -370,7 +372,7 @@ status()
 #> [1] 0
 #> 
 #> $daemons
-#> [1] "tcp://192.168.3.157:55701"
+#> [1] "tcp://192.168.1.71:42751"
 #> 
 #> $mirai
 #>  awaiting executing completed 
@@ -545,7 +547,7 @@ The printed return values may then be copy / pasted directly to a remote machine
 daemons(url = host_url())
 launch_remote()
 #> [1]
-#> Rscript -e 'mirai::daemon("tcp://192.168.3.157:55705")'
+#> Rscript -e 'mirai::daemon("tcp://192.168.1.71:35521")'
 daemons(0)
 ```
 
@@ -568,36 +570,36 @@ The generated self-signed certificate is available via `launch_remote()`, where 
 ``` r
 launch_remote(1)
 #> [1]
-#> Rscript -e 'mirai::daemon("tls+tcp://192.168.3.157:55709",tlscert=c("-----BEGIN CERTIFICATE-----
-#> MIIFQTCCAymgAwIBAgIBATANBgkqhkiG9w0BAQsFADA4MRYwFAYDVQQDDA0xOTIu
-#> MTY4LjMuMTU3MREwDwYDVQQKDAhOYW5vbmV4dDELMAkGA1UEBhMCSlAwHhcNMDEw
-#> MTAxMDAwMDAwWhcNMzAxMjMxMjM1OTU5WjA4MRYwFAYDVQQDDA0xOTIuMTY4LjMu
-#> MTU3MREwDwYDVQQKDAhOYW5vbmV4dDELMAkGA1UEBhMCSlAwggIiMA0GCSqGSIb3
-#> DQEBAQUAA4ICDwAwggIKAoICAQCD1jE9NqWz8P2lRwOQXLUWq+wuX7GWPXTzR26C
-#> PQkDwq9x/MCWxPCyufLgVAetBk2cS6ixX8gcOgPQ7/mT24YHm38OkJ7gweUAnjb8
-#> 40zVQbw9JCzdHI4AhNVjtDs0tr8qPEyFDmJ+U56tI2L3lEiYSBkEayUEPZqj2NyY
-#> jo0z2pqW3BbQ1tRRGQQ3ndKT91Qh33Hrq6xDHdo5S6JsyM6+X/4fz3ohr1a96ea9
-#> l/SVk1QXxmll7ZiqLFlxkX7J2IuKP8xn4VkvTupKuTNL+FW0rIDYRx2bRf8gPJS7
-#> JXw7pusiYHbNvzLi9g8mSJVtU1aEavyDCZiCkBPHzjkfg91LODvdCTrTzzRSAQeo
-#> Pao0b/GsnFAmeMAIIA1atIr1T+V/2kTGkxDB75xcDrdWkl0WL7Dx66FelS+noe5x
-#> QPmHlkYUQpgtm/SB+dzW5IyQAs3jEGauVGZVHcWxbdoJBqKjsgHnaVAJ/T9BYKUw
-#> zOBlzWjZb2nQadtS30hTPJBuX+paxmxwYUfFBiTQFr0dQFMQXxj28mVz8hwSk+QV
-#> a6OuYRbWduLvCT7b668L1ImoY3nC0DbKXGaL5ZHlQU7roNAgVehytQBj3zAemhlm
-#> q7m8dzSSbkfJ9gy7/llVmClXBpjc4tr6fD2tXHMfHUNrjnMl++hazcoSdLieeioM
-#> SMhkWwIDAQABo1YwVDASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBT30xuU
-#> UMV5Vj0t1y/TX+vIsUeaZjAfBgNVHSMEGDAWgBT30xuUUMV5Vj0t1y/TX+vIsUea
-#> ZjANBgkqhkiG9w0BAQsFAAOCAgEAbO5wt61zmmHHQXbyo2UT0q/yr3al8rJJw/LF
-#> +sAAKdAqgY9jcoLQwkRh4I5zU9Qwsn1mlOpuDPB47+JrE3gDENCdlR0SnZl0F2Wl
-#> inqrSwReIgwL5YpSIZOgKHSJjyVbov6f7eZis9Z054X9Nlw04hz3sIIQ6HaYQ5Zd
-#> msufQASGc9qH8lwAoPw2C6fKA4VrE98zHlvtk98fGv0Upi0xCiPr3T4/0g2H733D
-#> 56f01t5Eo6B2kuu9/BTJBpcdUa4IkroJLQ6mtHTVTChfHeopzJT6Kcv3xvOioyTp
-#> QHlEZbaLRyrI4ItQYAbzLgQ6gmPTekqfytLi1DSTrHbGhA4buldsGQHGV8+C/LYb
-#> 9iAbJoI7vq+czT6OzBreyBNeMPTd5nh97Uzn9JNoRFuqJkQ5mWJWO83iPRindZ8a
-#> f+4F2rizoZrHyBXQiu36XWAR71Mu5027FdE5RkZ8INNNvjlp8wEIUV4WIJUhd27i
-#> gW7d1tWO+YYjkD+N0tNEVZtB7xo2wJ3RuaKfS36Yp54P8HZdVJQr1vzVceb3ZpRA
-#> QadknMqVXTMVvpygQxhCTXiXyIqSS4yzKJZGSJQ7z7IEWBzFU8fF2uFvx9ZQ5sma
-#> mu21Zl2/fjOwYiTF2etFue/xJvvc8NFduIxgRf9DJchAQ8G7wKhqnAf/wXiH1sfA
-#> 9Li/iIk=
+#> Rscript -e 'mirai::daemon("tls+tcp://192.168.1.71:34667",tlscert=c("-----BEGIN CERTIFICATE-----
+#> MIIFPzCCAyegAwIBAgIBATANBgkqhkiG9w0BAQsFADA3MRUwEwYDVQQDDAwxOTIu
+#> MTY4LjEuNzExETAPBgNVBAoMCE5hbm9uZXh0MQswCQYDVQQGEwJKUDAeFw0wMTAx
+#> MDEwMDAwMDBaFw0zMDEyMzEyMzU5NTlaMDcxFTATBgNVBAMMDDE5Mi4xNjguMS43
+#> MTERMA8GA1UECgwITmFub25leHQxCzAJBgNVBAYTAkpQMIICIjANBgkqhkiG9w0B
+#> AQEFAAOCAg8AMIICCgKCAgEAnme8Ouxn2A3uTTYQ15OwxAVjKeG0OjAAYPuN2v0a
+#> J+Y+UYU7WTVup5bQZmMLDUvjKYHyyyEog9tZcWydwDsnT/TsYvLzL709Y4ijdlmN
+#> 8u780wXl5CIJueCsh91psFj/jnfFCUM8YoVyPqaBRrsil4v1wxidu5mQfiGnwadt
+#> DXs2rfYI8+PoSKniDfDgaODq8a73W0cvtT3jTaq6KlHUY+iD9uFgZIMxhOL905Wk
+#> V1lEVw9wLC0F0fRKN88wtsHwz02vY4jeznNBQ6s/Wr0QZReYXzC4rcqr6DwcJILv
+#> ue8RL319g7xgHxQsaJK6ouqRDCS2L3jlZyPjEMIgRoxyPwRxqbMZeMMC5cozeeZG
+#> Va4CpBWbHXq3Sv2WK0IJDTAat6R0iudfg9R85PKdUB7X5BMvoByjW/JsJFn5v36Y
+#> Jgda/5lRhUheGrELlhqVido/jiIImrS7kYoOQ++3RdJex7iwK/DMWn7I3ZbaxJRo
+#> 7BqIDhp5xhWbhezheFSnxX9CRV4kygB1eVbSy77Vz6aWU3upFUbPh5aJZFCR6LGu
+#> msRWw11p/srX4eth+rEwlm94m7MTjmYQNg0v7iWDQGyz4dkMZIEAgVawWoCXSBic
+#> XCbj66t0el8PDsbk8H2gOHDbxzI1I9/Icy6kxeFdVE9TDYNlUiJ9UH50MjG+8B19
+#> qYcCAwEAAaNWMFQwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUKtI8s3rN
+#> +shBp2mu/bUoOIkKIAAwHwYDVR0jBBgwFoAUKtI8s3rN+shBp2mu/bUoOIkKIAAw
+#> DQYJKoZIhvcNAQELBQADggIBAI3hsoJz1rwN/kgDe8xzUR+xJAPGhgQGlLSye1Er
+#> NyN28Is/ypgb6i+xRfwSKx6mt25jc2hdSWFrq1/HYPqzPdLiaoSfWUBymHo/wn/T
+#> mkGRhvHsdhxGB6gYROpMjIdcdxEDhfs7h7cOGEoSUAVC+yOMhwq/QYvIhJF1OEQf
+#> vmjANybY4dW83zaUDCInH0nvNCuGHeDmVBU4Sh5SzIk3Y8pZtjUBb7uVFPCjEan7
+#> PwQ8H3eU0ZJgAZw98b8ybUwwkRdosoLrDimoEGcRPsA5DCCU8c+SVJT3qz9qUzYW
+#> JfFWZ03xGLC4E0akdL1TT/jyaDP9PxVpWJPRozcea0OQtDGfmMUQkckPjfULJUH6
+#> wUJfhjcljX1F8km6ifKXc99+SaRg5eUewM7Sey1UeYNFefk8hUBPI5uxnakG+qWc
+#> 20uMDMILhQ8sGRIHpIyY/weS5aGlezHEy1Nn+RuVnb4JUQ5pwnrwc/VCmUgXk+1e
+#> E4zfC+HoyDYoSJ2Fl4rVGYJKcC5t513PL7YLo0b/BOXOUmgeO7nCKynfDtg56MLr
+#> gC4/Dea/9rBlZgGseYnEfghIJHFq6wssPSxW5QRmoxOJBx6Sbt8Y0ErF+uefBq6+
+#> G+CiB5x+xxmyHuUrvTcZXno50xvmfogkojxigAayUYN9D/x2iyUbW1XMq/0DCTmD
+#> Ygie
 #> -----END CERTIFICATE-----
 #> ",""))'
 ```
@@ -667,19 +669,19 @@ with_daemons("gpu", {
 })
 
 s1$daemons
-#> [1] "ipc:///tmp/0dab26920a871b96948d8f37"
+#> [1] "abstract://6445a1b45b31449004b05669"
 m1[]
-#> [1] 14269
+#> [1] 184128
 
 s2$daemons
-#> [1] "ipc:///tmp/df937735e3b736e564a4aa50"
+#> [1] "abstract://b6a644f4224076ec2aafb6d8"
 m2[] # different to m1
-#> [1] 14295
+#> [1] 184249
 
 m3[] # same as m1
-#> [1] 14269
+#> [1] 184128
 m4[] # same as m1
-#> [1] 14269
+#> [1] 184128
 
 with_daemons("cpu", daemons(0))
 with_daemons("gpu", daemons(0))


### PR DESCRIPTION
Instead store on the error object at `$condition.class`. Closes #400.