### PR TITLE
Warn on deprecated use of `require_daemons()` arguments

### DIFF
--- a/R/daemons.R
+++ b/R/daemons.R
@@ -493,6 +493,7 @@ daemons_set <- function(.compute = NULL) !is.null(compute_env(.compute))
 require_daemons <- function(.compute = NULL, call = environment()) {
   ensure_cli_initialized()
   is.environment(.compute) && {
+    warning("supplying `call` as the first argument of `require_daemons()` is deprecated")
     temp <- .compute
     .compute <- if (is.character(call)) call
     call <- temp

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -86,7 +86,7 @@ connection && {
   test_true(d <- daemons(1L, dispatcher = FALSE, asyncdial = FALSE, seed = 1546L))
   test_print(d)
   test_true(daemons_set())
-  test_true(require_daemons(parent.frame()))
+  test_true(suppressWarnings(require_daemons(parent.frame())))
   me <- mirai(mirai::mirai(), .timeout = 2000L)[]
   test_notnull(me)
   if (is_mirai_error(me)) test_type("list", me$stack.trace)


### PR DESCRIPTION
Follow up to #359 before removing this compatibility feature.