### PR TITLE
Add `.min` to `everywhere()` to synchronize remote daemon launches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 #### Updates
 
+* `everywhere()` adds argument `.min` to specify a minimum number of daemons on which to evaluate the expression (when using dispatcher).
+  This creates a synchronization point and can be useful when launching remote daemons to ensure that the expression has run on all daemons to connect.
 * Removes the following developer features:
   + `nextget("pid")` is no longer a supported option.
   + Argument `id` is removed at `daemon()`. This means that `status()` no longer reports daemon connection or disconnection events.

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -220,6 +220,11 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = NULL) 
 #' involve random numbers.
 #'
 #' @inheritParams mirai
+#' @param .min (only applicable when using dispatcher) the minimum number of
+#'   daemons on which to evaluate the expression. A synchronization point is
+#'   created ,whereby mirai evaluations resume only after these have finished.
+#'   This can be useful when launching remote daemons, to ensure that evaluation
+#'   has occurred on all daemons to connect.
 #'
 #' @return A 'mirai_map' (list of 'mirai' objects).
 #'
@@ -254,7 +259,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = NULL) 
 #'
 #' @export
 #'
-everywhere <- function(.expr, ..., .args = list(), .compute = NULL) {
+everywhere <- function(.expr, ..., .args = list(), .min = 1L, .compute = NULL) {
   require_daemons(.compute = .compute, call = environment())
   if (is.null(.compute)) .compute <- .[["cp"]]
   envir <- ..[[.compute]]
@@ -274,7 +279,7 @@ everywhere <- function(.expr, ..., .args = list(), .compute = NULL) {
   xlen <- if (is.null(envir[["dispatcher"]])) {
     max(stat(envir[["sock"]], "pipes"), envir[["n"]])
   } else {
-    info(.compute)[[1L]]
+    max(.min, info(.compute)[[1L]])
   }
   seed <- envir[["seed"]]
   on.exit({

--- a/man/everywhere.Rd
+++ b/man/everywhere.Rd
@@ -4,7 +4,7 @@
 \alias{everywhere}
 \title{Evaluate Everywhere}
 \usage{
-everywhere(.expr, ..., .args = list(), .compute = NULL)
+everywhere(.expr, ..., .args = list(), .min = 1L, .compute = NULL)
 }
 \arguments{
 \item{.expr}{an expression to evaluate asynchronously (of arbitrary length,
@@ -20,6 +20,12 @@ referenced, but not defined, in \code{.expr}, \strong{or} an environment contain
 such objects. These objects will remain local to the evaluation environment
 as opposed to those supplied in \code{...} above - see 'evaluation' section
 below.}
+
+\item{.min}{(only applicable when using dispatcher) the minimum number of
+daemons on which to evaluate the expression. A synchronization point is
+created ,whereby mirai evaluations resume only after these have finished.
+This can be useful when launching remote daemons, to ensure that evaluation
+has occurred on all daemons to connect.}
 
 \item{.compute}{[default NULL] character value for the compute profile
 to use (each has its own independent set of daemons), or NULL to use the


### PR DESCRIPTION
Fixes #330.