### PR TITLE
Minimize state at dispatcher - follow up to #461

### DIFF
--- a/R/dispatcher.R
+++ b/R/dispatcher.R
@@ -135,7 +135,6 @@ dispatcher <- function(host, url = NULL, n = 0L, ...) {
             for (item in outq) {
               item[["msgid"]] == id && {
                 send(psock, 0L, mode = 1L, pipe = item[["pipe"]], block = TRUE)
-                `[[<-`(item, "msgid", -1L)
                 found <- TRUE
                 break
               }


### PR DESCRIPTION
This is the logical counterpart to taking out the `outq[[id]][["msgid"]] < 0` check at dispatcher in #461.

We should not be trying to maintain any state ourselves where interrupts are involved as these are inherently racy and unsynchronizable.