### PR TITLE
Make sync daemons restore options and attached packages

### DIFF
--- a/R/daemon.R
+++ b/R/daemon.R
@@ -157,7 +157,6 @@ daemon <- function(
       (task >= maxtasks || maxtime && mclock() >= maxtime) && {
         .mark()
         send(ctx, eval_mirai(m), mode = 1L, block = TRUE)
-        if (cleanup) do_cleanup()
         xc <- 2L + (task >= maxtasks)
         wait(cv)
         break

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -670,11 +670,16 @@ ephemeral_daemon <- function(data, timeout) {
 }
 
 evaluate_sync <- function(envir) {
-  store <- as.list.environment(globalenv(), all.names = TRUE)
+  op <- options()
+  se <- search()
+  vars <- as.list.environment(globalenv(), all.names = TRUE)
   on.exit({
     `[[<-`(envir, "dmnenv", as.list.environment(globalenv(), all.names = TRUE))
+    new <- search()
+    lapply(new[!new %in% se], detach, character.only = TRUE)
+    options(op)
     rm(list = names(globalenv()), envir = globalenv())
-    list2env(store, envir = globalenv())
+    list2env(vars, envir = globalenv())
   })
   rm(list = names(globalenv()), envir = globalenv())
   list2env(envir[["dmnenv"]], envir = globalenv())


### PR DESCRIPTION
We relied on cleanup along the dameon exit branch previously, but now we've made `everywhere()` work, that does not guarantee the correct cleanup any more. Hence we replace that with the equivalent logic.