### PR TITLE
Fix deep stack traces on current R-devel (4.7)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,10 +25,10 @@ jobs:
         config:
           - {os: ubuntu-24.04-arm, r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,    r: 'release'}
-          - {os: ubuntu-latest,    r: 'oldrel-1'}
-          - {os: ubuntu-22.04,     r: 'oldrel-2'}
+          - {os: ubuntu-24.04,     r: 'oldrel-2'}
+          - {os: ubuntu-22.04,     r: 'oldrel-3'}
           - {os: macOS-latest,     r: 'release'}
-          - {os: macos-15-intel,   r: 'oldrel-3'}
+          - {os: macos-15-intel,   r: 'oldrel-1'}
           - {os: windows-latest,   r: 'release'}
           - {os: windows-latest,   r: 'oldrel-4'}
 

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -706,9 +706,6 @@ mk_mirai_error <- function(cnd) {
   }
   idx <- max(which(as.logical(lapply(sc, `==`, eval_call))))
   sc <- sc[(length(sc) - 1L):(idx + 1L)]
-  if (sc[[1L]][[1L]] == ".handleSimpleError") {
-    sc <- sc[-1L]
-  }
   cnd[["stack.trace"]] <- lapply(sc, `attributes<-`, NULL)
   `class<-`(`attributes<-`(msg, cnd), c("miraiError", "errorValue", "try-error"))
 }


### PR DESCRIPTION
Closes #587.

Due to some recent change between 17 and 22 Apr after the 4.6 release.

We take an expedient solution by removing this attempt to simplify deep stack traces more than necessary.