### PR TITLE
Use inproc sockets for sync daemons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* Reduces overhead for synchronous daemons.
 * Fixes `.handleSimpleError()` appearing in `$stack.trace` on a `miraiError` (regression in mirai 2.7.0).
 
 # mirai 2.7.0

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -243,7 +243,7 @@ daemons <- function(
   envir <- ..[[.compute]]
 
   if (sync) {
-    url <- local_url()
+    url <- inproc_url()
     dispatcher <- FALSE
     remote <- serial <- tls <- pass <- NULL
   }


### PR DESCRIPTION
Fixes #610.

We've already introduced the internal function `inproc_url()` for threaded dispatcher, so this is a simple swap.