### PR TITLE
Add headers argument to `http_config()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 #### Updates
 
-* Reduces overhead for synchronous daemons.
+* `http_config()` gains a `headers` argument, now the primary way to supply HTTP headers (including authentication such as session cookie, bearer token, or API key). `cookie` and `token` are retained as convenience arguments that append `Cookie:` and `Authorization: Bearer` entries to `headers` (thanks @ddl-dkelkhoff, #612).
+* Reduces overhead for synchronous daemons by using an in-process transport.
 * Fixes `.handleSimpleError()` appearing in `$stack.trace` on a `miraiError` (regression in mirai 2.7.0).
 
 # mirai 2.7.0

--- a/R/launchers.R
+++ b/R/launchers.R
@@ -373,15 +373,19 @@ cluster_config <- function(command = "sbatch", options = "", rscript = "Rscript"
 #' default, automatically configures for Posit Workbench using environment
 #' variables.
 #'
+#' Arguments accepting either a value or a function (`url`, `headers`, `data`,
+#' `cookie`, `token`) may be supplied as a function to defer evaluation until
+#' the time of launch. This is the recommended way to supply credentials, so
+#' that they are fetched lazily when needed rather than captured when the
+#' configuration is created.
+#'
 #' @param url (character or function) URL endpoint for the launch API. May be a
 #'   function returning the URL value.
 #' @param method (character) HTTP method, typically `"POST"`.
-#' @param cookie (character or function) session cookie value. May be a
-#'   function returning the cookie value. Set to `NULL` if not required for
-#'   authentication.
-#' @param token (character or function) authentication bearer token. May be a
-#'   function returning the token value. Set to `NULL` if not required for
-#'   authentication.
+#' @param headers (named character vector or function) HTTP headers sent with
+#'   the request, supplying any required authentication (e.g. session cookie,
+#'   bearer token, API key) as well as other API metadata. May be a function
+#'   returning a named character vector.
 #' @param data (character or function) JSON or formatted request body containing
 #'   the daemon launch command. May be a function returning the data value.
 #'   Should include a placeholder `"%s"` where the `mirai::daemon()` call
@@ -389,6 +393,12 @@ cluster_config <- function(command = "sbatch", options = "", rscript = "Rscript"
 #' @param ... additional arguments passed to `data` when it is a function.
 #'   See the Posit Workbench Options section for those accepted by the
 #'   default value of `data`.
+#' @param cookie (character or function) convenience argument that, if non-NULL,
+#'   appends a `Cookie: <value>` entry to `headers`. May be a function returning
+#'   the cookie value.
+#' @param token (character or function) convenience argument that, if non-NULL,
+#'   appends an `Authorization: Bearer <value>` entry to `headers`. May be a
+#'   function returning the token value.
 #'
 #' @inherit remote_config return
 #'
@@ -419,8 +429,10 @@ cluster_config <- function(command = "sbatch", options = "", rscript = "Rscript"
 #' http_config(
 #'   url = "https://api.example.com/launch",
 #'   method = "POST",
-#'   cookie = function() Sys.getenv("MY_SESSION_COOKIE"),
-#'   token = function() Sys.getenv("MY_API_KEY"),
+#'   headers = function() c(
+#'     Authorization = sprintf("Bearer %s", Sys.getenv("MY_API_KEY")),
+#'     `X-API-Version` = "2"
+#'   ),
 #'   data = '{"command": "%s"}'
 #' )
 #'
@@ -448,19 +460,21 @@ cluster_config <- function(command = "sbatch", options = "", rscript = "Rscript"
 http_config <- function(
   url = posit_workbench_url,
   method = "POST",
-  cookie = posit_workbench_cookie,
-  token = NULL,
+  headers = posit_workbench_headers,
   data = posit_workbench_data,
-  ...
+  ...,
+  cookie = NULL,
+  token = NULL
 ) {
   list(
     type = "http",
     url = url,
     method = method,
-    cookie = cookie,
-    token = token,
+    headers = headers,
     data = data,
-    dots = list(...)
+    dots = list(...),
+    cookie = cookie,
+    token = token
   )
 }
 
@@ -550,13 +564,13 @@ launch_remote_http <- function(n, remote, url, write_args, dots, envir, tls) {
   if (is.function(data)) {
     data <- do.call(data, remote[["dots"]])
   }
-  token <- resolve_field(remote[["token"]])
-  cookie <- resolve_field(remote[["cookie"]])
-  headers <- c(
-    Authorization = sprintf("Bearer %s", token),
-    Cookie = cookie,
-    `X-RS-Session-Server-RPC-Cookie` = cookie
-  )
+  headers <- resolve_field(remote[["headers"]])
+  if (!is.null(remote[["cookie"]])) {
+    headers <- c(headers, Cookie = resolve_field(remote[["cookie"]]))
+  }
+  if (!is.null(remote[["token"]])) {
+    headers <- c(headers, Authorization = sprintf("Bearer %s", resolve_field(remote[["token"]])))
+  }
   lapply(seq_len(n), function(i) {
     cmd <- write_args(url, dots, maybe_next_stream(envir), tls)
     cmd <- gsub("\\", "\\\\", cmd, fixed = TRUE)
@@ -588,9 +602,13 @@ find_dot <- function(args) {
   sel
 }
 
-posit_workbench_cookie <- function() {
-  is.null(.[["pwb_cookie"]]) || return(.[["pwb_cookie"]])
-  Sys.getenv("RS_SESSION_RPC_COOKIE")
+posit_workbench_headers <- function() {
+  cookie <- if (is.null(.[["pwb_cookie"]])) {
+    Sys.getenv("RS_SESSION_RPC_COOKIE")
+  } else {
+    .[["pwb_cookie"]]
+  }
+  c(Cookie = cookie, `X-RS-Session-Server-RPC-Cookie` = cookie)
 }
 
 posit_workbench_url <- function() {

--- a/R/launchers.R
+++ b/R/launchers.R
@@ -602,7 +602,9 @@ find_dot <- function(args) {
   sel
 }
 
-posit_workbench_headers <- function() {
+posit_workbench_headers <- function() pwb_headers()
+
+pwb_headers <- function() {
   cookie <- if (is.null(.[["pwb_cookie"]])) {
     Sys.getenv("RS_SESSION_RPC_COOKIE")
   } else {
@@ -611,11 +613,15 @@ posit_workbench_headers <- function() {
   c(Cookie = cookie, `X-RS-Session-Server-RPC-Cookie` = cookie)
 }
 
-posit_workbench_url <- function() {
+posit_workbench_url <- function() pwb_url()
+
+pwb_url <- function() {
   file.path(Sys.getenv("RS_SERVER_ADDRESS"), "api", "launch_job")
 }
 
-posit_workbench_data <- function(
+posit_workbench_data <- function(...) pwb_data(...)
+
+pwb_data <- function(
   rscript = "Rscript",
   job_name = "mirai_daemon",
   cluster = NULL,

--- a/man/http_config.Rd
+++ b/man/http_config.Rd
@@ -7,10 +7,11 @@
 http_config(
   url = posit_workbench_url,
   method = "POST",
-  cookie = posit_workbench_cookie,
-  token = NULL,
+  headers = posit_workbench_headers,
   data = posit_workbench_data,
-  ...
+  ...,
+  cookie = NULL,
+  token = NULL
 )
 }
 \arguments{
@@ -19,13 +20,10 @@ function returning the URL value.}
 
 \item{method}{(character) HTTP method, typically \code{"POST"}.}
 
-\item{cookie}{(character or function) session cookie value. May be a
-function returning the cookie value. Set to \code{NULL} if not required for
-authentication.}
-
-\item{token}{(character or function) authentication bearer token. May be a
-function returning the token value. Set to \code{NULL} if not required for
-authentication.}
+\item{headers}{(named character vector or function) HTTP headers sent with
+the request, supplying any required authentication (e.g. session cookie,
+bearer token, API key) as well as other API metadata. May be a function
+returning a named character vector.}
 
 \item{data}{(character or function) JSON or formatted request body containing
 the daemon launch command. May be a function returning the data value.
@@ -35,6 +33,14 @@ will be inserted at launch time.}
 \item{...}{additional arguments passed to \code{data} when it is a function.
 See the Posit Workbench Options section for those accepted by the
 default value of \code{data}.}
+
+\item{cookie}{(character or function) convenience argument that, if non-NULL,
+appends a \verb{Cookie: <value>} entry to \code{headers}. May be a function returning
+the cookie value.}
+
+\item{token}{(character or function) convenience argument that, if non-NULL,
+appends an \verb{Authorization: Bearer <value>} entry to \code{headers}. May be a
+function returning the token value.}
 }
 \value{
 A list in the required format to be supplied to the \code{remote} argument
@@ -44,6 +50,13 @@ of \code{\link[=daemons]{daemons()}} or \code{\link[=launch_remote]{launch_remot
 Generates a remote configuration for launching daemons via HTTP API. By
 default, automatically configures for Posit Workbench using environment
 variables.
+}
+\details{
+Arguments accepting either a value or a function (\code{url}, \code{headers}, \code{data},
+\code{cookie}, \code{token}) may be supplied as a function to defer evaluation until
+the time of launch. This is the recommended way to supply credentials, so
+that they are fetched lazily when needed rather than captured when the
+configuration is created.
 }
 \section{Posit Workbench Options}{
 
@@ -72,8 +85,10 @@ tryCatch(http_config(), error = identity)
 http_config(
   url = "https://api.example.com/launch",
   method = "POST",
-  cookie = function() Sys.getenv("MY_SESSION_COOKIE"),
-  token = function() Sys.getenv("MY_API_KEY"),
+  headers = function() c(
+    Authorization = sprintf("Bearer \%s", Sys.getenv("MY_API_KEY")),
+    `X-API-Version` = "2"
+  ),
   data = '{"command": "\%s"}'
 )
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -346,7 +346,7 @@ connection && NOT_CRAN && {
   test_true(daemons(url = host_url(tls = TRUE), pass = "test", serial = cfg))
   if (.Platform$OS.type == "unix") test_type("character", launch_remote(remote = cluster_config(command = "/bin/sh", options = "#SBATCH", rscript = file.path(R.home("bin"), "Rscript"))))
   test_type("list", launch_remote(2L, remote = http_config(url = "http://127.0.0.1:0", data = '{"cmd":"%s"}')))
-  test_type("list", launch_remote(1L, remote = http_config(url = "http://127.0.0.1:0", data = function(label) sprintf('{"cmd":"%%s","label":"%s"}', label), label = "x")))
+  test_type("list", launch_remote(1L, remote = http_config(url = "http://127.0.0.1:0", data = function(label) sprintf('{"cmd":"%%s","label":"%s"}', label), label = "x", cookie = "abc", token = function() "xyz")))
   test_equal(launch_local(1L), 1L)
   everywhere({})
   q <- quote({ list2env(list(b = 2), envir = globalenv()); 0L})

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -65,12 +65,14 @@ test_type("list", ssh_config("ssh://remotehost", tunnel = TRUE))
 test_equal(ssh_config("ssh://user@remotehost")$args[[1L]][2L], "user@remotehost")
 test_equal(ssh_config("ssh://remotehost")$args[[1L]][2L], "remotehost")
 test_type("list", cluster_config())
-test_type("list", cfg <- http_config(url = "https://example.com", cookie = "abc", data = '{"cmd":"%s"}'))
+test_type("list", cfg <- http_config(url = "https://example.com", cookie = "abc", headers = c(`X-API-Key` = "k"), data = '{"cmd":"%s"}'))
 test_equal(cfg$type, "http")
 test_equal(cfg$url, "https://example.com")
 test_equal(cfg$cookie, "abc")
 test_equal(cfg$data, '{"cmd":"%s"}')
+test_identical(cfg$headers, c(`X-API-Key` = "k"))
 test_identical(cfg$dots, list())
+test_type("closure", http_config()$headers)
 test_identical(http_config(data = '{"%s"}', cluster = "k8s", cpus = 4)$dots, list(cluster = "k8s", cpus = 4))
 test_true(is_mirai_interrupt(r <- mirai:::mk_mirai_interrupt()))
 test_print(r)
@@ -684,7 +686,7 @@ requireNamespace("secretbase", quietly = TRUE) && requireNamespace("later", quie
   old_cookie <- Sys.getenv("RS_SESSION_RPC_COOKIE")
   Sys.setenv(RS_SERVER_ADDRESS = "http://127.0.0.1", RS_SESSION_RPC_COOKIE = "test_cookie")
   test_equal(mirai:::posit_workbench_url(), "http://127.0.0.1/api/launch_job")
-  test_equal(mirai:::posit_workbench_cookie(), "test_cookie")
+  test_equal(mirai:::posit_workbench_headers()[["Cookie"]], "test_cookie")
   mock_cluster_json <- function(name = "k8s-cluster", image = "rstudio/r-base:latest", profile = "small")
     secretbase::jsonenc(list(
       result = list(clusters = list(list(
@@ -736,7 +738,7 @@ requireNamespace("secretbase", quietly = TRUE) && requireNamespace("later", quie
   test_equal(result[["data"]], "mock_api_response")
   dot[["pwb_cookie"]] <- NULL
   Sys.setenv(RS_SESSION_RPC_COOKIE = "env_cookie")
-  test_equal(mirai:::posit_workbench_cookie(), "env_cookie")
+  test_equal(mirai:::posit_workbench_headers()[["X-RS-Session-Server-RPC-Cookie"]], "env_cookie")
   call_count <- 0L
   ns[["ncurl"]] <- function(url, ...) {
     call_count <<- call_count + 1L
@@ -746,7 +748,7 @@ requireNamespace("secretbase", quietly = TRUE) && requireNamespace("later", quie
   result <- mirai:::posit_workbench_data()
   test_type("character", result)
   test_equal(dot[["pwb_cookie"]], "mock_browser_cookie")
-  test_equal(mirai:::posit_workbench_cookie(), "mock_browser_cookie")
+  test_equal(mirai:::posit_workbench_headers()[["Cookie"]], "mock_browser_cookie")
   dot[["pwb_cookie"]] <- NULL
   ns[["ncurl"]] <- function(url, ...) list(
     status = 200L, data = mock_cluster_json("cluster2", "image:v2", "large")
@@ -754,15 +756,15 @@ requireNamespace("secretbase", quietly = TRUE) && requireNamespace("later", quie
   result <- mirai:::posit_workbench_data()
   test_type("character", result)
   test_null(dot[["pwb_cookie"]])
-  test_equal(mirai:::posit_workbench_cookie(), "env_cookie")
+  test_equal(mirai:::posit_workbench_headers()[["Cookie"]], "env_cookie")
   dot[["pwb_cookie"]] <- old_pwb
   restore_binding(ns, "ncurl", original_ncurl)
   detach("tools:rstudio")
   if (nzchar(old_server)) Sys.setenv(RS_SERVER_ADDRESS = old_server) else Sys.unsetenv("RS_SERVER_ADDRESS")
   if (nzchar(old_cookie)) Sys.setenv(RS_SESSION_RPC_COOKIE = old_cookie) else Sys.unsetenv("RS_SESSION_RPC_COOKIE")
   test_type("character", mirai:::posit_workbench_url())
-  test_type("character", mirai:::posit_workbench_cookie())
-  nzchar(mirai:::posit_workbench_cookie()) || test_error(mirai:::posit_workbench_data(), "Posit Workbench")
+  test_type("character", mirai:::posit_workbench_headers())
+  nzchar(mirai:::posit_workbench_headers()[["Cookie"]]) || test_error(mirai:::posit_workbench_data(), "Posit Workbench")
 }
 test_false(daemons(0))
 Sys.sleep(1L)


### PR DESCRIPTION
Closes #612.

Adds a `headers` argument to `http_config()` so users can supply arbitrary HTTP headers. This addresses APIs that need custom auth (e.g. `X-API-Key`) or metadata beyond a cookie or bearer token.

`cookie` and `token` are kept as convenience shortcuts that append `Cookie:` and `Authorization: Bearer` entries.
