### PR TITLE
Make ephemeral daemons return invisibly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # mirai (development version)
 
+#### Updates
+
+* Ephemeral daemons return invisibly so that they do not print unnecessary output when this is being logged (thanks @jan-swissre, #619).
+
 # mirai 2.7.1
 
 #### Updates

--- a/R/daemon.R
+++ b/R/daemon.R
@@ -200,7 +200,7 @@ daemon <- function(
   dial(sock, url = url, autostart = NA, fail = 2L)
   `[[<-`(., "sock", sock)
   m <- recv(sock, mode = 1L, block = TRUE)
-  marked(send(sock, eval_mirai(m), mode = 1L, block = TRUE)) || wait(cv)
+  invisible(marked(send(sock, eval_mirai(m), mode = 1L, block = TRUE)) || wait(cv))
 }
 
 # internals --------------------------------------------------------------------


### PR DESCRIPTION
Fixes #619. Removes spurious output when this is logged.