### PR TITLE
Use `nanonext::run_event_loop()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,10 +24,9 @@ BugReports: https://github.com/r-lib/mirai/issues
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.9.0)
+    nanonext (>= 1.10.1)
 Suggests: 
     cli,
-    later,
     litedown,
     mori,
     otel,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 #### Updates
 
 * Ephemeral daemons return invisibly so that they do not print unnecessary output when this is being logged (thanks @jan-swissre, #619).
+* Requires nanonext >= 1.10.1.
 
 # mirai 2.7.1
 

--- a/R/launchers.R
+++ b/R/launchers.R
@@ -710,7 +710,7 @@ posit_workbench_fetch <- function(endpoint) {
   rs[[".rs.api.viewer"]](srv$url)
   timeout <- mclock() + .limit_short
   while (is.null(cookie) && mclock() < timeout) {
-    later::run_now(1L)
+    nanonext::run_event_loop(1000L)
   }
   is.null(cookie) && stop(._[["posit_api"]])
   rs[[".rs.api.executeCommand"]]("activateConsole")

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -493,20 +493,19 @@ connection && NOT_CRAN && {
 }
 # promises tests
 connection && requireNamespace("promises", quietly = TRUE) && NOT_CRAN && {
-  run_now <- getNamespace("later")[["run_now"]]
   test_true(daemons(1, notused = "wrongtype"))
   test_true(grepl("://", launch_remote(1L), fixed = TRUE))
   test_true(promises::is.promise(p1 <- promises::as.promise(mirai("completed"))))
   test_true(promises::is.promise(p2 <- promises::`%...>%`(mirai(Sys.sleep(0.1)), identity())))
   test_true(promises::is.promise(p3 <- promises::as.promise(call_mirai(mirai("completed")))))
   test_true(promises::is.promise(promises::then(mirai(stop()), identity, function(x) test_true(inherits(x, "simpleError")))))
-  run_now(1L)
+  nanonext::run_event_loop(1000L)
   test_true(promises::is.promise(promises::then(mirai(Sys.sleep(0.1), .timeout = 10), identity, function(x) test_true(inherits(x, "simpleError")))))
-  run_now(1L)
+  nanonext::run_event_loop(1000L)
   test_true(promises::is.promise(promises::then(call_mirai(mirai(stop())), identity, function(x) test_true(inherits(x, "simpleError")))))
-  run_now(1L)
+  nanonext::run_event_loop(1000L)
   test_true(promises::is.promise(promises::then(call_mirai(mirai(Sys.sleep(0.1), .timeout = 10)), identity, function(x) test_true(inherits(x, "simpleError")))))
-  run_now(1L)
+  nanonext::run_event_loop(1000L)
   test_zero(mirai_map(0:1, function(x) x, .promise = identity)[][[1L]])
   mat <- matrix(1:4, nrow = 2L)
   dimnames(mat) <- list(c("a", "b"), c("y", "x"))
@@ -515,7 +514,7 @@ connection && requireNamespace("promises", quietly = TRUE) && NOT_CRAN && {
   test_true(all(mp[.flat, .stop] == 2L))
   test_identical(names(mp[]), c("a", "b"))
   test_class("errorValue", mirai_map(1, function(x) stop(x), .promise = list(identity, identity))[][[1L]])
-  run_now(1L)
+  nanonext::run_event_loop(1000L)
   test_false(daemons(NULL))
 }
 # mirai daemon limits tests
@@ -689,7 +688,7 @@ connection && requireNamespace("otelsdk", quietly = TRUE) && NOT_CRAN && {
 }
 # Posit Workbench tests
 nzchar(Sys.getenv("RS_SERVER_ADDRESS")) || test_error(mirai:::posit_workbench_fetch("api/test"), "Posit Workbench")
-requireNamespace("secretbase", quietly = TRUE) && requireNamespace("later", quietly = TRUE) && {
+requireNamespace("secretbase", quietly = TRUE) && requireNamespace("promises", quietly = TRUE) && {
   old_server <- Sys.getenv("RS_SERVER_ADDRESS")
   old_cookie <- Sys.getenv("RS_SESSION_RPC_COOKIE")
   Sys.setenv(RS_SERVER_ADDRESS = "http://127.0.0.1", RS_SESSION_RPC_COOKIE = "test_cookie")


### PR DESCRIPTION
Added in nanonext 1.10.1. Allows us to remove `later` from suggests.