### PR TITLE
Performance: `mirai_map()` and `everywhere()` only perform validation once not per element

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 #### Updates
 
 * `mirai_map()` dispatches tasks with lower per-element overhead.
+* `everywhere()` dispatches with lower overhead, and errors upfront for a missing expression or invalid `...` arguments.
 * Ephemeral daemons return invisibly so that they do not print unnecessary output when this is being logged (thanks @jan-swissre, #619).
 * Requires nanonext >= 1.10.1.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* `mirai_map()` dispatches tasks with lower per-element overhead.
 * Ephemeral daemons return invisibly so that they do not print unnecessary output when this is being logged (thanks @jan-swissre, #619).
 * Requires nanonext >= 1.10.1.
 

--- a/R/map.R
+++ b/R/map.R
@@ -154,15 +154,22 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = N
   if (is.null(.compute)) {
     .compute <- .[["cp"]]
   }
+  envir <- ..[[.compute]]
 
   spn <- otel_map_span(.compute)
 
+  globals <- validate_globals(list(...))
+  disp <- envir[["dispatcher"]]
+  gated <- !is.null(disp) && !envir[["unbounded"]]
+
   dispatch_one <- function(elem, .expr) {
-    mirai(
-      .expr = .expr,
-      ...,
-      .args = list(.f = .f, .x = elem, .args = .args, .mirai_within_map = TRUE),
-      .compute = .compute
+    gated && .dispatcher_gate(disp)
+    do_mirai(
+      .expr,
+      globals,
+      list(.f = .f, .x = elem, .args = .args, .mirai_within_map = TRUE),
+      NULL,
+      envir
     )
   }
 

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -263,10 +263,12 @@ everywhere <- function(.expr, ..., .args = list(), .min = 1L, .compute = NULL) {
   }
   envir <- ..[[.compute]]
 
-  expr <- substitute(.expr)
-  .expr <- c(.snapshot, as.expression(resolve_expr(expr, .expr, parent.frame())))
+  v <- validate_dispatch(missing(.expr), list(...), .args)
+  expr <- c(.snapshot, as.expression(resolve_expr(substitute(.expr), .expr, parent.frame())))
 
-  xlen <- if (is.null(envir[["dispatcher"]])) {
+  disp <- envir[["dispatcher"]]
+  gated <- !is.null(disp) && !envir[["unbounded"]]
+  xlen <- if (is.null(disp)) {
     max(stat(envir[["sock"]], "pipes"), envir[["n"]])
   } else {
     max(.min, info(.compute)[[1L]])
@@ -275,10 +277,11 @@ everywhere <- function(.expr, ..., .args = list(), .min = 1L, .compute = NULL) {
   on.exit(`[[<-`(envir, "seed", seed))
   `[[<-`(envir, "seed", NULL)
   vec <- lapply(seq_len(xlen), function(i) {
+    gated && .dispatcher_gate(disp)
     if (i < xlen) {
-      marked(mirai(.expr, ..., .args = .args, .compute = .compute))
+      marked(do_mirai(expr, v[[1L]], v[[2L]], NULL, envir))
     } else {
-      mirai(.expr, ..., .args = .args, .compute = .compute)
+      do_mirai(expr, v[[1L]], v[[2L]], NULL, envir)
     }
   })
   `[[<-`(envir, "everywhere", vec)

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -142,14 +142,14 @@
 mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = NULL) {
   v <- validate_dispatch(missing(.expr), list(...), .args)
   envir <- compute_env(.compute)
-  expr <- substitute(.expr)
+  expr <- resolve_expr(substitute(.expr), .expr, parent.frame())
 
   if (!is.null(envir)) {
     disp <- envir[["dispatcher"]]
     is.null(disp) || envir[["unbounded"]] || .dispatcher_gate(disp)
   }
 
-  do_mirai(expr, .expr, v[[1L]], v[[2L]], .timeout, envir, parent.frame())
+  do_mirai(expr, v[[1L]], v[[2L]], .timeout, envir)
 }
 
 #' @rdname mirai
@@ -186,7 +186,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = NULL) 
 try_mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = NULL) {
   v <- validate_dispatch(missing(.expr), list(...), .args)
   envir <- compute_env(.compute)
-  expr <- substitute(.expr)
+  expr <- resolve_expr(substitute(.expr), .expr, parent.frame())
 
   if (!is.null(envir)) {
     disp <- envir[["dispatcher"]]
@@ -195,7 +195,7 @@ try_mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = NU
     }
   }
 
-  do_mirai(expr, .expr, v[[1L]], v[[2L]], .timeout, envir, parent.frame())
+  do_mirai(expr, v[[1L]], v[[2L]], .timeout, envir)
 }
 
 #' Evaluate Everywhere
@@ -652,16 +652,7 @@ conditionMessage.miraiError <- function(c) attr(c, "message")
 
 validate_dispatch <- function(missing_expr, globals, args, where = sys.call(-1L)) {
   missing_expr && stop(simpleError(._[["missing_expression"]], call = where))
-  if (length(globals)) {
-    gn <- names(globals)
-    if (is.null(gn)) {
-      is.environment(globals[[1L]]) || stop(simpleError(._[["named_dots"]], call = where))
-      globals <- as.list.environment(globals[[1L]], all.names = TRUE)
-      globals[[".Random.seed"]] <- NULL
-    } else if (!all(nzchar(gn))) {
-      stop(simpleError(._[["named_dots"]], call = where))
-    }
-  }
+  globals <- validate_globals(globals, where)
   if (length(args)) {
     if (is.environment(args)) {
       args <- as.list.environment(args, all.names = TRUE)
@@ -672,6 +663,20 @@ validate_dispatch <- function(missing_expr, globals, args, where = sys.call(-1L)
   list(globals, args)
 }
 
+validate_globals <- function(globals, where = sys.call(-1L)) {
+  if (length(globals)) {
+    gn <- names(globals)
+    if (is.null(gn)) {
+      is.environment(globals[[1L]]) || stop(simpleError(._[["named_dots"]], call = where))
+      globals <- as.list.environment(globals[[1L]], all.names = TRUE)
+      globals[[".Random.seed"]] <- NULL
+    } else if (!all(nzchar(gn))) {
+      stop(simpleError(._[["named_dots"]], call = where))
+    }
+  }
+  globals
+}
+
 resolve_expr <- function(expr, .expr, parent) {
   if (is.symbol(expr) && exists(as.character(expr), envir = parent) && is.language(.expr)) {
     .expr
@@ -680,13 +685,13 @@ resolve_expr <- function(expr, .expr, parent) {
   }
 }
 
-do_mirai <- function(expr, .expr, globals, .args, .timeout, envir, parent) {
+do_mirai <- function(expr, globals, .args, .timeout, envir) {
   ctx_spn <- otel_mirai_span(envir)
   if (length(envir[["seed"]])) {
     globals[[".Random.seed"]] <- next_stream(envir)
   }
   data <- list(
-    ._expr_. = resolve_expr(expr, .expr, parent),
+    ._expr_. = expr,
     ._globals_. = globals,
     ._otel_. = ctx_spn[[1L]]
   )

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -220,6 +220,8 @@ connection && {
   test_error(mirai_map(1:2, identity, 1), "all `...` arguments must be named")
   test_identical(mirai_map(list(1, NULL), is.null)[], list(FALSE, TRUE))
   test_true(all(mirai_map(1:2, function(x) x + y, as.environment(list(y = 10)))[.flat] == 11:12))
+  test_error(everywhere(), "missing expression, perhaps wrap in {}?")
+  test_error(everywhere({}, 1), "all `...` arguments must be named")
   test_false(daemons(0L))
 }
 # parallel cluster tests

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -217,6 +217,9 @@ connection && {
   test_type("language", mirai_map(list(quote(1+2)), identity)[][[1]])
   test_class("Date", mirai_map(data.frame(x = as.Date("2020-01-01")), identity)[][[1]])
   test_true(is_mirai_error(mirai_map(1:2, function(x) daemons(1))[][[1]]))
+  test_error(mirai_map(1:2, identity, 1), "all `...` arguments must be named")
+  test_identical(mirai_map(list(1, NULL), is.null)[], list(FALSE, TRUE))
+  test_true(all(mirai_map(1:2, function(x) x + y, as.environment(list(y = 10)))[.flat] == 11:12))
   test_false(daemons(0L))
 }
 # parallel cluster tests
@@ -422,6 +425,10 @@ connection && NOT_CRAN && {
   test_zero(qs[["used"]])
   test_true(qs[["peak"]] > 0)
   test_false(daemons(0L))
+  # mirai_map dispatch applies the memory gate per task
+  test_true(daemons(1, memory = 1))
+  test_true(all(mirai_map(1:4, function(x) x + 1L)[.flat] == 2:5))
+  test_false(daemons(0L))
 }
 # try_mirai non-blocking submission tests
 connection && NOT_CRAN && {
@@ -598,15 +605,18 @@ connection && NOT_CRAN && {
   test_type("character", launch_remote())
   test_class("mirai_map", everywhere(TRUE, .min = 3L))
   m <- mirai_map(1:12, rnorm)[]
+  m2 <- mirai_map(1:3, function(x) rnorm(1L) * y, y = 10)[]
   test_false(daemons(0))
   test_true(daemons(4, dispatcher = FALSE, seed = 1234L, .compute = "gpu"))
   with_daemons("gpu", {
     test_class("mirai_map", everywhere(TRUE))
     n <- mirai_map(1:12, rnorm)[]
+    n2 <- mirai_map(1:3, function(x) rnorm(1L) * y, y = 10)[]
     test_false(daemons(NULL))
   })
   test_false(daemons_set("gpu"))
   test_identical(m, n)
+  test_identical(m2, n2)
 }
 # dispatcher L'Ecuyer-CMRG C implementation tests
 connection && NOT_CRAN && {


### PR DESCRIPTION
Lower overhead from `mirai_map()` and `everywhere()` calling the internal `do_mirai()` rather than the public `mirai()`.