### PR TITLE
Snapshot options by value for daemon cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * `mirai_map()` dispatches tasks with lower per-element overhead.
 * `everywhere()` dispatches with lower overhead, and errors upfront for a missing expression or invalid `...` arguments.
 * Ephemeral daemons return invisibly so that they do not print unnecessary output when this is being logged (thanks @jan-swissre, #619).
+* Fixes daemon cleanup not restoring options modified during evaluation, as the recorded options tracked subsequent changes by reference (#631).
 * Requires nanonext >= 1.10.1.
 
 # mirai 2.7.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,8 @@
 
 * `mirai_map()` dispatches tasks with lower per-element overhead.
 * `everywhere()` dispatches with lower overhead, and errors upfront for a missing expression or invalid `...` arguments.
+* Fixes daemon cleanup not restoring options modified during evaluation (#631).
 * Ephemeral daemons return invisibly so that they do not print unnecessary output when this is being logged (thanks @jan-swissre, #619).
-* Fixes daemon cleanup not restoring options modified during evaluation, as the recorded options tracked subsequent changes by reference (#631).
 * Requires nanonext >= 1.10.1.
 
 # mirai 2.7.1

--- a/R/daemon.R
+++ b/R/daemon.R
@@ -249,7 +249,7 @@ do_cleanup <- function() {
 }
 
 snapshot <- function() {
-  `[[<-`(`[[<-`(`[[<-`(., "op", .Options), "se", search()), "vars", names(globalenv()))
+  `[[<-`(`[[<-`(`[[<-`(., "op", as.list(.Options)), "se", search()), "vars", names(globalenv()))
 }
 
 flag_value <- function(autoexit) {

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -339,6 +339,11 @@ connection && NOT_CRAN && {
   q <- quote(list2env(list(b = 2), envir = globalenv()))
   m <- mirai("Seattle", .timeout = 1000)
   if (!is_error_value(m[])) test_equal(m[], "Seattle")
+  od <- mirai(getOption("digits"), .timeout = 1000)[]
+  if (!is_error_value(od)) {
+    test_equal(mirai({ options(digits = getOption("digits") + 1L); getOption("digits") })[], od + 1L)
+    test_equal(mirai(getOption("digits"))[], od)
+  }
   test_class("errorValue", mirai(q(), .timeout = 1000)[])
   test_true(daemons(sync = TRUE, .compute = "seq"))
   with_daemons("seq", {


### PR DESCRIPTION
`snapshot()` stored `.Options` directly, but that is the live options object which `options()` modifies in place, so the saved state tracked every subsequent change and the cleanup restore was a no-op. Snapshotting `as.list(.Options)` takes a real copy, at a cost of ~1µs at daemon startup.

Closes #631.
