### PR TITLE
Fix daemon crash for errors raised before evaluation begins

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* Fixes daemon crash for errors raised before evaluation begins (#633).
 * `mirai_map()` dispatches tasks with lower per-element overhead.
 * `everywhere()` dispatches with lower overhead, and errors upfront for a missing expression or invalid `...` arguments.
 * Fixes daemon cleanup not restoring options modified during evaluation (#631).

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -765,12 +765,14 @@ mk_mirai_error <- function(cnd) {
   } else {
     sprintf("Error in %s: %s", call, .subset2(cnd, "message"))
   }
-  idx <- max(which(as.logical(lapply(sc, `==`, eval_call))))
-  sc <- sc[(length(sc) - 1L):(idx + 1L)]
-  if (identical(sc[[1L]][[1L]], quote(.handleSimpleError))) {
-    sc <- sc[-1L]
+  idx <- which(as.logical(lapply(sc, `==`, eval_call)))
+  if (length(idx)) {
+    sc <- sc[(length(sc) - 1L):(max(idx) + 1L)]
+    if (identical(sc[[1L]][[1L]], quote(.handleSimpleError))) {
+      sc <- sc[-1L]
+    }
+    cnd[["stack.trace"]] <- lapply(sc, `attributes<-`, NULL)
   }
-  cnd[["stack.trace"]] <- lapply(sc, `attributes<-`, NULL)
   `class<-`(`attributes<-`(msg, cnd), c("miraiError", "errorValue", "try-error"))
 }
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -585,6 +585,11 @@ connection && NOT_CRAN && {
     tryCatch(m[.stop], error = identity)
   }
   test_equal(info()[["connections"]], 1L)
+  everywhere({ assign("lk", 0L, envir = globalenv()); lockBinding("lk", globalenv()) })
+  e <- mirai(0L, lk = 1L, .timeout = 1000)[]
+  test_class("miraiError", e)
+  test_null(e$stack.trace)
+  test_equal(mirai("alive", .timeout = 1000)[], "alive")
   test_false(daemons(0))
 }
 # additional stress testing


### PR DESCRIPTION
If an error occurred before the eval frame existed, such as when assignment of `...` globals into the daemon's global environment failed, `mk_mirai_error()` found no eval frame on the stack and itself errored while extracting the stack trace. This secondary error escaped `daemon()`, killing the daemon process, with the host receiving an errorValue 19 rather than a miraiError.

The stack trace is now only trimmed and attached when the eval frame is found, so such errors return a regular miraiError (message intact, no stack trace) and the daemon survives to take the next task.

Closes #633.