### PR TITLE
Remove ineffective promise cache from as.promise.mirai_map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* Removes an ineffective promise cache from the `as.promise()` method for 'mirai_map' objects.
 * Fixes `mirai_map()` collection option `.flat` ignoring an 'errorValue' in the first element (#639).
 * Fixes `daemon()` returning exit code 1 (idletime) instead of 2 (walltime) when `walltime` elapses while idle (#637).
 * Fixes `race_mirai()` not waiting for resolution on compute profiles set with `url` and `dispatcher = FALSE` (#635).

--- a/R/promises.R
+++ b/R/promises.R
@@ -89,15 +89,7 @@ handle_fulfilled <- function(value, .visible) {
 #'
 #' @exportS3Method promises::as.promise
 #'
-as.promise.mirai_map <- function(x) {
-  promise <- attr(x, "promise")
-
-  if (is.null(promise)) {
-    attr(x, "promise") <- promises::promise_all(.list = x) -> promise
-  }
-
-  promise
-}
+as.promise.mirai_map <- function(x) promises::promise_all(.list = x)
 
 #' @exportS3Method promises::is.promising
 #'


### PR DESCRIPTION
The memoization in `as.promise.mirai_map()` has never functioned: a 'mirai_map' is a plain list, so `attr(x, "promise") <-` triggers copy-on-modify and sets the attribute on a function-local duplicate that is discarded on return. Every call has therefore always built a fresh `promise_all()`, and nothing else reads the attribute.

This makes the method the one-liner it has always effectively been. No behavioural change: the per-element promises carry the real caching (mirai are environments, so that cache does persist), and repeated conversions of the same map produce equivalent promises over those shared element promises — verified identical resolution before and after. Existing promises tests cover the method, so no new test is added.